### PR TITLE
HMRC-765: Use shared workflow for e2e tests and specify base url

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -4,23 +4,10 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
+
 jobs:
-  test:
-    environment: development
-    timeout-minutes: 60
-    runs-on: ubuntu-22.04
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: lts/*
-    - name: Install dependencies
-      run: npm install -g yarn && yarn
-    - name: Check code
-      run: yarn run lint
-    - name: Install Playwright Browsers
-      run: yarn playwright install --with-deps chromium
-    - name: Run Playwright tests
-      run: yarn run test-development
-      env:
-        CI: true
+  run-tests:
+    uses: trade-tariff/trade-tariff-tools/.github/workflows/e2e-tests.yml@main
+    with:
+      test-url: "https://dev.trade-tariff.service.gov.uk"

--- a/package.json
+++ b/package.json
@@ -8,15 +8,12 @@
   "devDependencies": {
     "@eslint/js": "^9.21.0",
     "@playwright/test": "1.50.1",
-    "dotenv": "^16.4.7",
     "eslint": "^9.21.0",
     "globals": "^16.0.0"
   },
   "scripts": {
     "lint": "eslint . --ext .js",
     "fix": "eslint . --ext .js --fix",
-    "test-development": "PLAYWRIGHT_ENV=development playwright test",
-    "test-staging": "PLAYWRIGHT_ENV=staging playwright test",
-    "test-production": "PLAYWRIGHT_ENV=production playwright test"
+    "test": "playwright test"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,13 +1,9 @@
 import { defineConfig, devices } from "@playwright/test";
-import dotenv from "dotenv";
-import path from "path";
 
-const playwrightEnv = process.env.PLAYWRIGHT_ENV ?? "development";
-const envFile = path.resolve(__dirname, `.env.${playwrightEnv}`);
-dotenv.config({ path: envFile });
+const baseURL = process.env.BASE_URL || "https://dev.trade-tariff.service.gov.uk";
+const onCI = (process.env.CI ?? "false") === "true";
 
 // See https://playwright.dev/docs/test-configuration.
-const onCI = (process.env.CI ?? "false") === "true";
 export default defineConfig({
   testDir: "./tests",
   fullyParallel: true,
@@ -15,10 +11,7 @@ export default defineConfig({
   retries: onCI ? 2 : 0,
   workers: onCI ? 1 : undefined,
   reporter: "html",
-  use: { trace: "on" },
-  // TODO: Set the timeout that makes sense for the OTT project
-  // timeout: 140000,
-
+  use: { trace: "on", baseURL: baseURL },
   projects: [
     {
       name: "chromium",


### PR DESCRIPTION
# Jira link

[HMRC-765](https://transformuk.atlassian.net/browse/HMRC-765)

## What?

I have:

- [x] Added support for a base url option via the environment
- [x] Added the shared workflow to this ci build as a first test of the shared workflow

## Why?

I am doing this because:

- This is needed to support parameterised workflows of the e2e tests
