### PR TITLE
Validate tariff duty calculator functionality in repo

### DIFF
--- a/tests/dutyCalculatorTheTariff.spec.js
+++ b/tests/dutyCalculatorTheTariff.spec.js
@@ -1,0 +1,9 @@
+const { test, expect } = require("@playwright/test");
+
+test.describe("Tariff Duty Calculator End -to -End Test", () => {
+  test("Validating the duty calculator Workflow", async ({ page }) => {
+    await page.goto("/commodities/0702001007");
+    await page.getByRole("link", { name: "work out the duties and taxes" }).click();
+    await expect(page.getByText("Calculate import duties")).toBeVisible();
+  });
+});


### PR DESCRIPTION
# Jira link

[HMRC-837\<https://transformuk.atlassian.net/browse/HMRC-837>](https://transformuk.atlassian.net/browse/HMRC-<TODO>)

## What?

I have:

-  Implemented a validation process for the tariff duty calculator in the current environment.


## Why?

I am doing this because:

- We need to confirm that the tariff duty calculator functions correctly in the current environment.
-This helps in identifying any potential discrepancies or issues before further integration. 
- Ensured that business logic aligns with expected duty calculations.
