### PR TITLE
Added test for Rules of Origin Display functionality

### DIFF
--- a/tests/rulesOfOriginDisplayTheTariff.spec.js
+++ b/tests/rulesOfOriginDisplayTheTariff.spec.js
@@ -2,15 +2,12 @@ const { test, expect } = require('@playwright/test');
 
 test.describe("Rules of origin Display", () => {
   test("Verify Rules of Origin are displayed for selected commodity", async ({ page }) => {
-    await page.goto("/find_commodity");
-    await page.getByRole('combobox', { name: 'Search the UK Integrated' }).click();
-    await page.getByRole('combobox', { name: 'Search the UK Integrated' }).fill('0409000010');
-    await page.getByRole('combobox', { name: 'Search the UK Integrated' }).press('Enter');
+    await page.goto("/commodities/0409000010");
     await page.getByRole('combobox', { name: 'Select or enter a country' }).click();
     await page.getByRole('option', { name: 'Albania (AL)' }).click();
     await page.getByRole('button', { name: 'Set country' }).click();
     await page.getByRole('tab', { name: 'Origin' }).click();
     await expect(page.getByRole('heading', { name: 'Preferential rules of origin for trading with Albania Flag for Albania' })).toBeVisible();
     await expect(page.getByRole('columnheader', { name: 'Agreement' })).toBeVisible();
-})
+  })
 });

--- a/tests/rulesOfOriginDisplayTheTariff.spec.js
+++ b/tests/rulesOfOriginDisplayTheTariff.spec.js
@@ -1,0 +1,16 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe("Rules of origin Display", () => {
+  test("Verify Rules of Origin are displayed for selected commodity", async ({ page }) => {
+    await page.goto("/find_commodity");
+    await page.getByRole('combobox', { name: 'Search the UK Integrated' }).click();
+    await page.getByRole('combobox', { name: 'Search the UK Integrated' }).fill('0409000010');
+    await page.getByRole('combobox', { name: 'Search the UK Integrated' }).press('Enter');
+    await page.getByRole('combobox', { name: 'Select or enter a country' }).click();
+    await page.getByRole('option', { name: 'Albania (AL)' }).click();
+    await page.getByRole('button', { name: 'Set country' }).click();
+    await page.getByRole('tab', { name: 'Origin' }).click();
+    await expect(page.getByRole('heading', { name: 'Preferential rules of origin for trading with Albania Flag for Albania' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Agreement' })).toBeVisible();
+})
+});


### PR DESCRIPTION
# Jira link

[HMRC-839\<https://transformuk.atlassian.net/browse/HMRC-839>](https://transformuk.atlassian.net/browse/HMRC-<TODO>)

## What?

I have:

- Added a test for Rules of Origin Display


## Why?

I am doing this because:

- Ensuring the Rules of Origin Display is correctly validated in the UI.
- Improving test coverage and reliability
- Automating the validation process for better efficiency

