### PR TITLE
Add a production check on a schedule

### DIFF
--- a/.github/workflows/check-production.yml
+++ b/.github/workflows/check-production.yml
@@ -1,0 +1,11 @@
+name: Check Production
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+
+jobs:
+  run-tests:
+    uses: trade-tariff/trade-tariff-tools/.github/workflows/e2e-tests.yml@main
+    with:
+      test-url: "https://www.trade-tariff.service.gov.uk"
+      ref: ${{ github.sha }}


### PR DESCRIPTION
Adding the entire suite to run against production on a 10 minute schedule.

Ultimately, these results can be exported to NR for monitoring/alerting, but let's just get it running for now.