### PR TITLE
Add NewRelic Export for Production Check

### DIFF
--- a/.github/workflows/newrelic-exporter.yml
+++ b/.github/workflows/newrelic-exporter.yml
@@ -1,0 +1,23 @@
+name: "New Relic Exporter"
+
+on:
+  workflow_run:
+    workflows: ['Check Production']
+    types: [completed]
+
+env:
+  GHA_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
+  GHA_RUN_ID: ${{ github.event.workflow_run.id }}
+  GHA_RUN_NAME: ${{ github.event.workflow_run.name }}
+
+jobs:
+  new-relic-exporter:
+    name: new-relic-exporter
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: new-relic-exporter
+        uses: newrelic-experimental/gha-new-relic-exporter@1.0.0


### PR DESCRIPTION
Exports run data from the production check to New Relic for reporting.

We may need to add more to this, but for now we need to see what NR outputs