### PR TITLE
 Extend exchange rates checks to validate 'View Online' page loading

### DIFF
--- a/tests/validateExchangeRates.spec.js
+++ b/tests/validateExchangeRates.spec.js
@@ -6,7 +6,15 @@ test.describe("Exchange Rates", () => {
     await expect(page.getByRole('heading', { name: 'Check foreign currency' })).toBeVisible();
     await page.getByRole('link', { name: 'Currency exchange average' }).click();
     await expect(page.getByRole('heading', { name: 'HMRC currency exchange' })).toBeVisible();
+    await page.getByTitle("View 12 2024 monthly exchange").click();
+    await expect(page.getByRole("columnheader", { name: "Country/territory" })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: "Currency units per £" })).toBeVisible();
+    await page.getByRole("link", { name: "Average exchange rates" }).click();
     await page.getByRole('link', { name: 'Currency exchange spot rates' }).click();
     await expect(page.getByRole('heading', { name: 'HMRC currency exchange spot' })).toBeVisible();
+    await page.getByTitle("View 12 2024 monthly exchange").click();
+    await expect(page.getByRole("columnheader", { name: "Currency units per £" })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: "Country/territory" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "HM Revenue & Customs" })).toBeVisible();
   });
 });

--- a/tests/validateExchangeRates.spec.js
+++ b/tests/validateExchangeRates.spec.js
@@ -3,18 +3,22 @@ const { test, expect } = require('@playwright/test');
 test.describe("Exchange Rates", () => {
   test("Validating exchange rates", async ({ page }) => {
     await page.goto("/exchange_rates");
-    await expect(page.getByRole('heading', { name: 'Check foreign currency' })).toBeVisible();
-    await page.getByRole('link', { name: 'Currency exchange average' }).click();
-    await expect(page.getByRole('heading', { name: 'HMRC currency exchange' })).toBeVisible();
-    await page.getByTitle("View 12 2024 monthly exchange").click();
+
+    // Validate monthly exchange rates
+    await page.locator('a[title^="View"]').first().click();
     await expect(page.getByRole("columnheader", { name: "Country/territory" })).toBeVisible();
-    await expect(page.getByRole("columnheader", { name: "Currency units per £" })).toBeVisible();
+    await page.getByRole("link", { name: "Monthly exchange rates" }).click();
+
+    // Validate average exchange rates
+    await page.getByRole('link', { name: 'Currency exchange average rates' }).click();
+    await page.locator('a[title^="View"]').first().click();
+    await expect(page.getByRole("columnheader", { name: "Country/territory" })).toBeVisible();
     await page.getByRole("link", { name: "Average exchange rates" }).click();
+
+    // Validate spot exchange rates
     await page.getByRole('link', { name: 'Currency exchange spot rates' }).click();
-    await expect(page.getByRole('heading', { name: 'HMRC currency exchange spot' })).toBeVisible();
-    await page.getByTitle("View 12 2024 monthly exchange").click();
-    await expect(page.getByRole("columnheader", { name: "Currency units per £" })).toBeVisible();
+    await page.locator('a[title^="View"]').first().click();
     await expect(page.getByRole("columnheader", { name: "Country/territory" })).toBeVisible();
-    await expect(page.getByRole("link", { name: "HM Revenue & Customs" })).toBeVisible();
+    await page.getByRole("link", { name: "Spot exchange rates" }).click();
   });
 });


### PR DESCRIPTION


# Jira link

[HMRC-882\<https://transformuk.atlassian.net/browse/HMRC-882>](https://transformuk.atlassian.net/browse/HMRC-<TODO>)

## What?
This PR updates the existing validations by adding checks for the two "View Online " links:
 
-    Currency exchange average rates
-    Currency exchange spot rates

  
I have:

- I identified and clicked the first visible 'View Online' link for each type.
- Added validations to ensure the page loads successfully.


## Why?

I am doing this because:

- It requires validating the external pages linked for average and spot rates.
- This ensures the user can access the correct online page from the main page.
- It enhances the robustness of our automated journey test coverage.
