### PR TITLE
HMRC-883: Navigate the updates in the admin UI

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+Playwright_ADMIN_OTP_SECRET=FZVPA4BXLHJ5JTCSVIBXQDZH4J23Z42M
+Playwright_ADMIN_PASSWORD=!V83*.8sKeAu
+Playwright_ADMIN_USERNAME=bhavani.bandla@digital.hmrc.gov.uk
+Playwright_ADMIN_URL=https://admin.staging.trade-tariff.service.gov.uk

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "lint": "eslint . --ext .js",
     "fix": "eslint . --ext .js --fix",
     "test": "playwright test"
+  },
+  "dependencies": {
+    "otplib": "^12.0.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from "@playwright/test";
+require('dotenv').config();
 
 const baseURL = process.env.BASE_URL || "https://dev.trade-tariff.service.gov.uk";
 const onCI = (process.env.CI ?? "false") === "true";

--- a/tests/Admin/navigateUpdatesInAdminUI.spec.js
+++ b/tests/Admin/navigateUpdatesInAdminUI.spec.js
@@ -1,0 +1,33 @@
+import { test, expect, beforeEach } from "@playwright/test";
+import { authenticator } from "otplib";
+
+test.describe("admin login test", () => {
+  test.describe.configure({mode: 'serial'});
+  test.beforeEach(async ({ page }) => {
+    const adminUrl = process.env.Playwright_ADMIN_URL;
+    const username = process.env.Playwright_ADMIN_USERNAME;
+    const password = process.env.Playwright_ADMIN_PASSWORD;
+    const otpSecret = process.env.Playwright_ADMIN_OTP_SECRET;
+    const token = authenticator.generate(otpSecret); // Generate the OTP token
+    await page.goto(adminUrl);
+    await page.getByRole("textbox", { name: "Email" }).fill(username);
+    await page.getByRole("textbox", { name: "Password" }).fill(password);
+    await page.getByRole("button", { name: "Sign in" }).click();
+    await page.getByRole("textbox", { name: "Code from app" }).fill(token);
+    await page.getByRole("button", { name: "Sign in" }).click();
+  });
+
+  test("Validate UK updates", async ({ page }) => {
+    await page.getByRole("listitem").filter({ hasText: "Updates" }).click();
+    await expect(page.getByRole("heading", { name: "Tariff Updates - CDS" })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "Issue date" })).toBeVisible();
+  });
+
+  test("Validate XI updates", async ({ page }) => {
+    await page.getByRole("link", { name: "Switch to XI service" }).click();
+    await page.getByRole("listitem").filter({ hasText: "Updates" }).click();
+    await expect(page.getByRole("heading", { name: "Tariff Updates - Taric" })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "Issue date" })).toBeVisible();
+  });
+
+});

--- a/tests/a-zNavigationOfTheTariff.spec.js
+++ b/tests/a-zNavigationOfTheTariff.spec.js
@@ -6,4 +6,4 @@ test.describe("A-Z Navigation", () => {
     await page.getByRole('link', { name: 'Aa batteries (code: 8506)', exact: true }).click();
     await expect(page.getByRole('heading', { name: 'Heading 8506 - Primary cells' })).toBeVisible()
   });
-})
+});

--- a/tests/browseTheTariff.spec.js
+++ b/tests/browseTheTariff.spec.js
@@ -9,4 +9,4 @@ test.describe("Browse Page", () => {
     await page.getByRole('link', { name: 'Commodity code 0101210000,' }).click();
     await expect(page.getByLabel('Breadcrumb').getByText('Commodity')).toBeVisible();
   });
-})
+});

--- a/tests/rulesOfOriginDisplayOnTheTariff.spec.js
+++ b/tests/rulesOfOriginDisplayOnTheTariff.spec.js
@@ -9,5 +9,5 @@ test.describe("Rules of origin Display", () => {
     await page.getByRole('tab', { name: 'Origin' }).click();
     await expect(page.getByRole('heading', { name: 'Preferential rules of origin for trading with Albania Flag for Albania' })).toBeVisible();
     await expect(page.getByRole('columnheader', { name: 'Agreement' })).toBeVisible();
-  })
+  });
 });

--- a/tests/searchTheTariff.spec.js
+++ b/tests/searchTheTariff.spec.js
@@ -7,5 +7,5 @@ test.describe("Find Commodity Page", () => {
     await page.getByRole('combobox', { name: 'Search the UK Integrated' }).fill('clothes');
     await page.getByRole('combobox', { name: 'Search the UK Integrated' }).press('Enter');
     await expect(page.getByRole('heading', { name: 'Results matching ‘clothes’' })).toBeVisible();
-  })
-})
+  });
+});

--- a/tests/validateTheDutyCalculator.spec.js
+++ b/tests/validateTheDutyCalculator.spec.js
@@ -25,5 +25,5 @@ test.describe("Duty Calculator Integration", () => {
     await expect(page.getByRole('heading', { name: 'Import duty calculation' })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Option 1: Third-country duty" })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Option 2: Tariff preference' })).toBeVisible();
-  })
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,6 +91,44 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz"
   integrity sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==
 
+"@otplib/core@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/core/-/core-12.0.1.tgz#73720a8cedce211fe5b3f683cd5a9c098eaf0f8d"
+  integrity sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==
+
+"@otplib/plugin-crypto@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz#2b42c624227f4f9303c1c041fca399eddcbae25e"
+  integrity sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==
+  dependencies:
+    "@otplib/core" "^12.0.1"
+
+"@otplib/plugin-thirty-two@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/plugin-thirty-two/-/plugin-thirty-two-12.0.1.tgz#5cc9b56e6e89f2a1fe4a2b38900ca4e11c87aa9e"
+  integrity sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==
+  dependencies:
+    "@otplib/core" "^12.0.1"
+    thirty-two "^1.0.2"
+
+"@otplib/preset-default@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/preset-default/-/preset-default-12.0.1.tgz#cb596553c08251e71b187ada4a2246ad2a3165ba"
+  integrity sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==
+  dependencies:
+    "@otplib/core" "^12.0.1"
+    "@otplib/plugin-crypto" "^12.0.1"
+    "@otplib/plugin-thirty-two" "^12.0.1"
+
+"@otplib/preset-v11@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@otplib/preset-v11/-/preset-v11-12.0.1.tgz#4c7266712e7230500b421ba89252963c838fc96d"
+  integrity sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==
+  dependencies:
+    "@otplib/core" "^12.0.1"
+    "@otplib/plugin-crypto" "^12.0.1"
+    "@otplib/plugin-thirty-two" "^12.0.1"
+
 "@playwright/test@1.50.1":
   version "1.50.1"
   resolved "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz"
@@ -483,6 +521,15 @@ optionator@^0.9.3:
     type-check "^0.4.0"
     word-wrap "^1.2.5"
 
+otplib@^12.0.1:
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/otplib/-/otplib-12.0.1.tgz#c1d3060ab7aadf041ed2960302f27095777d1f73"
+  integrity sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==
+  dependencies:
+    "@otplib/core" "^12.0.1"
+    "@otplib/preset-default" "^12.0.1"
+    "@otplib/preset-v11" "^12.0.1"
+
 p-limit@^3.0.2:
   version "3.1.0"
   resolved "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz"
@@ -566,6 +613,11 @@ supports-color@^7.1.0:
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
+
+thirty-two@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/thirty-two/-/thirty-two-1.0.2.tgz#4ca2fffc02a51290d2744b9e3f557693ca6b627a"
+  integrity sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
# Jira link

[HMRC-883\<https://transformuk.atlassian.net/browse/HMRC-883>](https://transformuk.atlassian.net/browse/HMRC-<TODO>)

## What?
- Navigated to the updates page of the admin UI
- Verified  that at least one update is visible
- Switched to the XI service.
- Verified that at least one update is visible in the XI service.

I have:

- [ ] Added navigation to the updates page in the admin UI.
- [ ] Added logic to verify update visibility
- [ ] added support to switch to the XI service and verify updates there

## Why?

I am doing this because:

- We need to validate that updates are correctly shown in both the admin and XI services, ensuring the user journey is working as expected for both environments. 
