### PR TITLE
HMRC-885: Enable navigation and edit functionality in admin notes UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "scripts": {
     "lint": "eslint . --ext .js",
     "fix": "eslint . --ext .js --fix",
-    "test": "playwright test"
+    "test": "playwright test --workers 2"
   }
 }

--- a/pages/loginPage.js
+++ b/pages/loginPage.js
@@ -1,0 +1,25 @@
+import { test } from "@playwright/test";
+
+export default class LoginPage {
+  constructor(page, testInfo) {
+    this.page = page;
+    this.isProduction = !!testInfo.project.use.baseURL.match(/www.trade-tariff.service.gov.uk/);
+    this.adminUrl = process.env.ADMIN_URL;
+    this.password = process.env.BASIC_PASSWORD;
+  }
+
+  async login() {
+    if (this.isProduction) {
+      test.skip('Skipping in production');
+    } else {
+      await this.page.goto(this.adminUrl);
+
+      await this.page.getByRole(
+        "textbox",
+        { id: "basic-session-password-field" }
+      ).fill(this.password);
+
+      await this.page.getByRole("button", { name: "Continue" }).click();
+    }
+  }
+}

--- a/tests/adminUI-notesNav.spec.js
+++ b/tests/adminUI-notesNav.spec.js
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Search References", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    const isProduction = !!testInfo.project.use.baseURL.match(/www.trade-tariff.service.gov.uk/);
+    const adminUrl = process.env.ADMIN_URL;
+    const password = process.env.BASIC_PASSWORD;
+    test.skip(isProduction, 'Skipping in production');
+    await page.goto(adminUrl);
+    await page.getByRole("textbox", { id: "basic-session-password-field" }).fill(password);
+    await page.getByRole("button", { name: "Continue" }).click();
+  });
+
+test("displays UK section notes and allows chapter notes editing", async ({ page }) => {
+await page.getByRole('link', { name: 'Section & chapter notes' }).click();
+await expect(page.getByRole('heading', { name: 'Section Notes' })).toBeVisible();
+await page.getByRole('link', { name: 'to 5' }).click();
+await expect(page.getByRole('cell', { name: 'to 6' })).toBeVisible();
+await page.getByRole('row', { name: '1 to 6 Live Animals Edit' }).getByRole('link').click();
+await expect(page.getByRole('heading', { name: 'Edit Chapter Note' })).toBeVisible();
+await expect(page.getByRole('button', { name: 'Update Chapter note' })).toBeVisible();
+await page.getByRole('link', { name: 'Back', exact: true }).click();
+});
+
+test("displays XI section notes and allows chapter notes editing", async ({ page,}) => {
+  await page.getByRole("link", { name: "Switch to XI service" }).click();
+  await page.getByRole("link", { name: "Section & chapter notes" }).click();
+  await expect(page.getByRole("heading", { name: "Section Notes" })).toBeVisible();
+  await page.getByRole("link", { name: "to 5" }).click();
+  await expect(page.getByRole("cell", { name: "to 6" })).toBeVisible();
+  await page.locator("#chapter_01").getByRole("cell", { name: "Edit" }).click();
+  await expect(page.getByRole("heading", { name: "Edit Chapter Note" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Update Chapter note" })).toBeVisible();
+  await page.getByRole("link", { name: "Back", exact: true }).click();
+});
+
+ })

--- a/tests/adminUI-notesNav.spec.js
+++ b/tests/adminUI-notesNav.spec.js
@@ -1,37 +1,21 @@
 import { test, expect } from "@playwright/test";
+import LoginPage from '../pages/loginPage.js';
 
-test.describe("Search References", () => {
-  test.beforeEach(async ({ page }, testInfo) => {
-    const isProduction = !!testInfo.project.use.baseURL.match(/www.trade-tariff.service.gov.uk/);
-    const adminUrl = process.env.ADMIN_URL;
-    const password = process.env.BASIC_PASSWORD;
-    test.skip(isProduction, 'Skipping in production');
-    await page.goto(adminUrl);
-    await page.getByRole("textbox", { id: "basic-session-password-field" }).fill(password);
-    await page.getByRole("button", { name: "Continue" }).click();
+test.describe("Notes", () => {
+  test.beforeEach(async ({ page }, testInfo) => await new LoginPage(page, testInfo).login());
+
+  test("displays UK section notes and allows chapter notes editing", async ({ page }) => {
+    await page.getByRole('link', { name: 'Section & chapter notes' }).click();
+    await page.getByRole('link', { name: 'to 5' }).click();
+    await page.getByRole('row', { name: '1 to 6 Live Animals Edit' }).getByRole('link').click();
+    await expect(page.getByRole('button', { name: 'Update Chapter note' })).toBeVisible();
   });
 
-test("displays UK section notes and allows chapter notes editing", async ({ page }) => {
-await page.getByRole('link', { name: 'Section & chapter notes' }).click();
-await expect(page.getByRole('heading', { name: 'Section Notes' })).toBeVisible();
-await page.getByRole('link', { name: 'to 5' }).click();
-await expect(page.getByRole('cell', { name: 'to 6' })).toBeVisible();
-await page.getByRole('row', { name: '1 to 6 Live Animals Edit' }).getByRole('link').click();
-await expect(page.getByRole('heading', { name: 'Edit Chapter Note' })).toBeVisible();
-await expect(page.getByRole('button', { name: 'Update Chapter note' })).toBeVisible();
-await page.getByRole('link', { name: 'Back', exact: true }).click();
-});
-
-test("displays XI section notes and allows chapter notes editing", async ({ page,}) => {
-  await page.getByRole("link", { name: "Switch to XI service" }).click();
-  await page.getByRole("link", { name: "Section & chapter notes" }).click();
-  await expect(page.getByRole("heading", { name: "Section Notes" })).toBeVisible();
-  await page.getByRole("link", { name: "to 5" }).click();
-  await expect(page.getByRole("cell", { name: "to 6" })).toBeVisible();
-  await page.locator("#chapter_01").getByRole("cell", { name: "Edit" }).click();
-  await expect(page.getByRole("heading", { name: "Edit Chapter Note" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Update Chapter note" })).toBeVisible();
-  await page.getByRole("link", { name: "Back", exact: true }).click();
-});
-
- })
+  test("displays XI section notes and allows chapter notes editing", async ({ page, }) => {
+    await page.getByRole("link", { name: "Switch to XI service" }).click();
+    await page.getByRole("link", { name: "Section & chapter notes" }).click();
+    await page.getByRole("link", { name: "to 5" }).click();
+    await page.locator("#chapter_01").getByRole("cell", { name: "Edit" }).click();
+    await expect(page.getByRole("button", { name: "Update Chapter note" })).toBeVisible();
+  });
+})

--- a/tests/adminUI-searchRefs.spec.js
+++ b/tests/adminUI-searchRefs.spec.js
@@ -1,15 +1,8 @@
 import { test, expect } from "@playwright/test";
+import LoginPage from '../pages/loginPage.js';
 
 test.describe("Search References", () => {
-  test.beforeEach(async ({ page }, testInfo) => {
-    const isProduction = !!testInfo.project.use.baseURL.match(/www.trade-tariff.service.gov.uk/);
-    const adminUrl = process.env.ADMIN_URL;
-    const password = process.env.BASIC_PASSWORD;
-    test.skip(isProduction, 'Skipping in production');
-    await page.goto(adminUrl);
-    await page.getByRole("textbox", { id: "basic-session-password-field" }).fill(password);
-    await page.getByRole("button", { name: "Continue" }).click();
-  });
+  test.beforeEach(async ({ page }, testInfo) => await new LoginPage(page, testInfo).login());
 
   test("should display UK search references", async ({ page }) => {
     await page.getByRole("link", { name: "Search references" }).click();

--- a/tests/adminUI-updateNav.spec.js
+++ b/tests/adminUI-updateNav.spec.js
@@ -1,15 +1,8 @@
 import { test, expect } from "@playwright/test";
+import LoginPage from '../pages/loginPage.js';
 
 test.describe("Admin updates", () => {
-  test.beforeEach(async ({ page }, testInfo) => {
-    const isProduction = !!testInfo.project.use.baseURL.match(/www.trade-tariff.service.gov.uk/);
-    const adminUrl = process.env.ADMIN_URL;
-    const password = process.env.BASIC_PASSWORD;
-    test.skip(isProduction, 'Skipping in production');
-    await page.goto(adminUrl);
-    await page.getByRole("textbox", { id: "basic-session-password-field" }).fill(password);
-    await page.getByRole("button", { name: "Continue" }).click();
-  });
+  test.beforeEach(async ({ page }, testInfo) => await new LoginPage(page, testInfo).login());
 
   test("Validate UK updates", async ({ page }) => {
     await page.getByRole("listitem").filter({ hasText: "Updates" }).click();


### PR DESCRIPTION
# Jira link

[HMRC-885\<https://transformuk.atlassian.net/browse/HMRC-885>](https://transformuk.atlassian.net/browse/HMRC-<TODO>)

## What?

I have:

- [ ] Added navigation to the notes page in the admin UI
- [ ] Verified that chapter ranges and sections are clickable
- [ ] Checked that the edit link is visible and functional


## Why?

I am doing this because:

- We need to confirm that user can access and edit notes from the admin interface.
- This forms part of validating the notes journey flow in the UI
- Ensure that the admin user experience supports note management properly
