### PR TITLE
BAU: Reflect admin UI fixes

### DIFF
--- a/tests/adminUI-notes-nav.spec.js
+++ b/tests/adminUI-notes-nav.spec.js
@@ -5,18 +5,16 @@ test.describe("Notes", () => {
   test.beforeEach(async ({ page }, testInfo) => await new LoginPage(process.env.ADMIN_URL, page, testInfo, true).login());
 
   test("displays UK section notes and allows chapter notes editing", async ({ page }) => {
-    await page.getByRole('link', { name: 'Section & chapter notes' }).click();
-    await page.getByRole('link', { name: 'to 5' }).click();
-    await page.getByRole('row', { name: '1 to 6 Live Animals Edit' }).getByRole('link').click();
+    await page.getByRole('link', { name: '1 to 5' }).click();
+    await page.getByRole('row', { name: '0101 to 0106' }).getByRole('link').click();
 
     await expect(page.getByRole('button', { name: 'Update Chapter note' })).toBeVisible();
   });
 
   test("displays XI section notes and allows chapter notes editing", async ({ page, }) => {
     await page.getByRole("link", { name: "Switch to XI service" }).click();
-    await page.getByRole("link", { name: "Section & chapter notes" }).click();
-    await page.getByRole("link", { name: "to 5" }).click();
-    await page.locator("#chapter_01").getByRole("cell", { name: "Edit" }).click();
+    await page.getByRole('link', { name: '1 to 5' }).click();
+    await page.getByRole('row', { name: '0101 to 0106' }).getByRole('link').click();
 
     await expect(page.getByRole("button", { name: "Update Chapter note" })).toBeVisible();
   });

--- a/tests/adminUI-search-refs.spec.js
+++ b/tests/adminUI-search-refs.spec.js
@@ -6,21 +6,20 @@ test.describe("Search References", () => {
 
   test("should display UK search references", async ({ page }) => {
     await page.getByRole("link", { name: "Search references" }).click();
-    await page.getByRole("link", { name: "Search references" }).click();
-    await page.getByRole("link", { name: "to 5" }).click();
-    await page.getByRole("link", { name: "to 6" }).click();
+    await page.getByRole("link", { name: "1 to 5" }).click();
+    await page.getByRole("link", { name: "0101 to 0106" }).click();
     await page.getByRole("link", { name: "Commodities in 0101" }).click();
 
-    await expect(page.getByRole("heading", { name: "Commodities search references" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Commodities search references of heading 0101:Live Horses, Asses, Mules And Hinnies" })).toBeVisible();
   });
 
   test("should display XI Search references", async ({ page }) => {
     await page.getByRole("link", { name: "Switch to XI service" }).click();
     await page.getByRole("link", { name: "Search references" }).click();
-    await page.getByRole("link", { name: "to 5" }).click();
-    await page.getByRole("link", { name: "to 6" }).click();
+    await page.getByRole("link", { name: "1 to 5" }).click();
+    await page.getByRole("link", { name: "0101 to 0106" }).click();
     await page.getByRole("link", { name: "Commodities in 0101" }).click();
 
-    await expect(page.getByRole("heading", { name: "Commodities search references" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Commodities search references of heading 0101:Live Horses, Asses, Mules And Hinnies" })).toBeVisible();
   });
 });


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- [x] Reflect admin UI fixes

## Why?

I am doing this because:

- There were bugs in the admin UI that I noticed/fixed during a HER migration (see https://github.com/trade-tariff/trade-tariff-admin/pull/894)
