### PR TITLE
HMRC-694: Reflect change in duty calculator location

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "fix": "eslint . --ext .js --fix",
     "lint": "eslint . --ext .js",
-    "test": "playwright test --workers 2"
+    "test": "playwright test --workers 2",
+    "test-local": "playwright test"
   },
   "version": "1.0.0"
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -12,7 +12,7 @@ export default defineConfig({
   retries: onCI ? 2 : 0,
   workers: onCI ? 1 : undefined,
   reporter: "html",
-  use: { trace: "on", baseURL: baseURL },
+  use: { trace: "off", baseURL: baseURL },
   projects: [
     {
       name: "chromium",

--- a/tests/validate-duty-calculator.spec.js
+++ b/tests/validate-duty-calculator.spec.js
@@ -14,7 +14,7 @@ test.describe("Duty Calculator Integration", () => {
     await page.getByRole('button', { name: 'Continue' }).click();
 
     // Navigate through the import origin step
-    await page.locator("//input[@id='steps-country-of-origin-country-of-origin-field']").click();
+    await page.locator("//input[@id='duty-calculator-steps-country-of-origin-country-of-origin-field']").click();
     await page.getByRole('combobox', { name: 'Where are the goods coming' }).fill('Canada');
     await page.getByRole('combobox', { name: 'Where are the goods coming' }).press('Enter');
     await page.getByRole('button', { name: 'Continue' }).click();


### PR DESCRIPTION
# Jira link

[HMRC-694](https://transformuk.atlassian.net/browse/HMRC-694)

## What?

I have:

- [x] Added support for local testing (e.g. maximum worker numbers)
- [x] Fixed an id reference in the duty calculator test

## Why?

I am doing this because:

- This is required to make the e2e tests pass
