### PR TITLE
Increase test timeout to support preview environments

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -19,6 +19,7 @@ export default defineConfig({
     trace: "off",
     baseURL: process.env.BASE_URL,
   },
+  timeout: 600 * 1000, // 10 minutes
   projects: [
     {
       name: "chromium",


### PR DESCRIPTION
# Jira link

[HMRC-\<TODO\>](https://transformuk.atlassian.net/browse/HMRC-<TODO>)

## What?

I have:

- [x] Increased the test timeout by adding test.setTimeout(300000).

## Why?

I am doing this because:

- Allow tests to pass reliably in slower environments (e.g. Preevy preview) by giving them more time to complete.
