### PR TITLE
HMRC-1459: Validate exchange rate files

### DIFF
--- a/tests/validate-exchange-rates.spec.js
+++ b/tests/validate-exchange-rates.spec.js
@@ -1,25 +1,34 @@
 import { test, expect } from '@playwright/test';
 import LoginPage from '../pages/loginPage.js';
+import DownloadHelper from '../utils/downloadHelper.js';
 
 test.describe("Exchange Rates", () => {
-  test("Validating exchange rates", async ({ page }) => {
-    await new LoginPage("/exchange_rates", page).login()
-
-    // Validate monthly exchange rates
+  test("Validating monthly exchange rates", async ({ page }) => {
+    await new LoginPage("/exchange_rates", page).login();
     await page.locator('a[title^="View"]').first().click();
     await expect(page.getByRole("columnheader", { name: "Country/territory" })).toBeVisible();
     await page.getByRole("link", { name: "Monthly exchange rates" }).click();
 
-    // Validate average exchange rates
+    await DownloadHelper.downloadAndVerify(page, page.getByRole('link', { name: /CSV\s+\d+\.?\d*\s*KB/ }).first());
+  });
+
+  test("Validating average exchange rates", async ({ page }) => {
+    await new LoginPage("/exchange_rates", page).login();
     await page.getByRole('link', { name: 'Currency exchange average rates' }).click();
     await page.locator('a[title^="View"]').first().click();
     await expect(page.getByRole("columnheader", { name: "Country/territory" })).toBeVisible();
     await page.getByRole("link", { name: "Average exchange rates" }).click();
 
-    // Validate spot exchange rates
+    await DownloadHelper.downloadAndVerify(page, page.getByRole('link', { name: /CSV\s+\d+\.?\d*\s*KB/ }).first());
+  });
+
+  test("Validating spot exchange rates", async ({ page }) => {
+    await new LoginPage("/exchange_rates", page).login();
     await page.getByRole('link', { name: 'Currency exchange spot rates' }).click();
     await page.locator('a[title^="View"]').first().click();
     await expect(page.getByRole("columnheader", { name: "Country/territory" })).toBeVisible();
     await page.getByRole("link", { name: "Spot exchange rates" }).click();
+
+    await DownloadHelper.downloadAndVerify(page, page.getByRole('link', { name: /CSV\s+\d+\.?\d*\s*KB/ }).first());
   });
 });

--- a/utils/downloadHelper.js
+++ b/utils/downloadHelper.js
@@ -1,0 +1,13 @@
+import { expect } from '@playwright/test';
+
+export default class DownloadHelper {
+  static async downloadAndVerify(page, linkLocator, filenamePattern = /\.csv$/i, options = { timeout: 10000 }) {
+    await expect(linkLocator).toBeVisible();
+    const downloadPromise = page.waitForEvent('download', options);
+    await linkLocator.click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(filenamePattern);
+    expect(await download.failure()).toBeNull();
+    return download;
+  }
+}


### PR DESCRIPTION
# Jira link

[HMRC-1459](https://transformuk.atlassian.net/browse/HMRC-1459)

## What?

I have:

- [x] Added validations of exchange rate file downloads

## Why?

I am doing this because:

- These were broken during a recent refactor and they're part of our core flows for users
