### PR TITLE
BAU: Support hidden configuration in .env

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,10 +1,16 @@
 import { defineConfig, devices } from "@playwright/test";
 import path from "path";
 import dotenv from "dotenv";
+import fs from "fs";
 
 const playwrightEnv = process.env.PLAYWRIGHT_ENV ?? 'development'
 const envFile = path.resolve(__dirname, `.env.${playwrightEnv}`)
 dotenv.config({ path: envFile })
+const hasEnvFile = fs.existsSync(envFile);
+
+if (hasEnvFile) {
+  dotenv.config({ path: '.env' })
+}
 
 // See https://playwright.dev/docs/test-configuration.
 const onCI = (process.env.CI ?? "false") === "true";


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- [x] Added support for loading additional configuration in .env

## Why?

I am doing this because:

- This file is .gitignored so we can safely populate it with configuration we want (e.g. skip certain tests that require AWS credentials)
