### PR TITLE
test(HMRC-1496 ) : add e2e test for simplified procedural measures Val…

### DIFF
--- a/tests/validate-simplified-procedural-measures.spec.js
+++ b/tests/validate-simplified-procedural-measures.spec.js
@@ -1,0 +1,24 @@
+import { test, expect } from "@playwright/test";
+import LoginPage from "../pages/loginPage.js";
+
+test.describe("Simplified Procedural Measures", () => {
+  test("allows switching between the by date and by code views", async ({
+    page,
+  }) => {
+    await new LoginPage("/simplified_procedure_value", page).login();
+
+    await page.selectOption("select", { index: 1 });
+    await page
+      .getByRole("button", { name: "View rates for selected date" })
+      .click();
+
+    const rowCount = await page.locator("tbody tr").count();
+    expect(rowCount).toBeGreaterThan(0);
+
+    await page.locator("tbody tr td a").first().click();
+
+    await expect(page).toHaveURL(
+      /\/simplified_procedure_value\?simplified_procedural_code=\d+\.\d+\.\d+/,
+    );
+  });
+});


### PR DESCRIPTION
…idation

# Jira link

[HMRC-1496-Simplified Procedural Measures validation](https://transformuk.atlassian.net/browse/HMRC-1496)

## What?

I have:

- [ ] Added e2e test for simplified procedural measures validation
- [ ] Covered navigation to '/Simplified_ Procedure_value'
- [ ] Validated first year view shows at least one item and correct URL
- [ ] Validated deep dive view on a specific simplified procedural code

## Why?

I am doing this because:

- We need automated test coverage for the simplified procedural measures tool
- Reduce the risk of regressions when making changes to this feature

