### PR TITLE
BAU: Update stale e2e checks

### DIFF
--- a/tests/navigation-a-to-z-tariff.spec.js
+++ b/tests/navigation-a-to-z-tariff.spec.js
@@ -5,11 +5,11 @@ test.describe("A-Z Navigation", () => {
   test("Validating a-z navigation of the tariff", async ({ page }) => {
     await new LoginPage("/a-z-index/a", page).login();
     await page
-      .getByRole("link", { name: "Aa batteries (code: 8506)", exact: true })
+      .getByRole("link", { name: "Abaci (abacus) (code: 9503)", exact: true })
       .click();
 
     await expect(
-      page.getByRole("heading", { name: "Heading 8506 - Primary cells" }),
+      page.getByRole("heading", { name: "Heading 9503 - Tricycles" }),
     ).toBeVisible();
   });
 });


### PR DESCRIPTION
## What changed

- Updated the A-Z tariff navigation spec to use the current production reference `Abaci (abacus) (code: 9503)`.

## Why

Production no longer includes the old `Aa batteries (code: 8506)` search reference, so the A-Z e2e spec was asserting obsolete search-reference data.

The frontend last-updated timestamp check is already handled on `main` by skipping the affected updates spec, so this PR now leaves that existing `main` change intact.
