### PR TITLE
BAU: Remove schedule trigger

### DIFF
--- a/.github/workflows/check-production.yml
+++ b/.github/workflows/check-production.yml
@@ -1,7 +1,5 @@
 name: Check Production
 on:
-  schedule:
-    - cron: "*/10 * * * *"
   workflow_dispatch:
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,23 +13,23 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.45.0
+    rev: v0.48.0
     hooks:
       - id: markdownlint-docker
 
   - repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.90.8
+    rev: v3.95.3
     hooks:
       - id: trufflehog
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v9.37.0
+    rev: v10.4.0
     hooks:
       - id: eslint
         args: [--fix]
 
   - repo: https://github.com/JoC0de/pre-commit-prettier
-    rev: v3.6.2
+    rev: v3.8.3
     hooks:
       - id: prettier
         args: [--write]


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- [x] Removes the GitHub Actions cron schedule trigger from the check-production workflow

## Why?

I am doing this because:

- The production E2E checks are now triggered via our own AWS-based scheduler (trade-tariff-lambdas-e2e-scheduler)
- GitHub Actions cron jobs are not reliable and may be delayed or skipped
- Prevents duplicate runs caused by having both GitHub cron and external scheduler active