### PR TITLE
Update Slack alert to only trigger after 2 consecutive test failures

### DIFF
--- a/.github/workflows/check-production.yml
+++ b/.github/workflows/check-production.yml
@@ -36,7 +36,7 @@ jobs:
 
   on-failure:
     runs-on: ubuntu-latest
-    if: ${{always() && needs.get_previous_status.outputs.previous_status == 'success' && needs.run-tests.result != 'success'}}
+    if: ${{always() && needs.get_previous_status.outputs.previous_status != 'success' && needs.run-tests.result != 'success'}}
     needs:
       - get_previous_status
       - run-tests


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- Updated workflow condition so Slack alerts are sent only when the current run fails and the previous run also failed.

## Why

- Avoid noisy alerts from transient failures
- Ensure notifications are sent only for persistent issues (2 failures in a row)