### PR TITLE
BAU: Log structured healthcheck responses

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/global-setup.js
+++ b/global-setup.js
@@ -8,6 +8,46 @@ dotenv.config({ path: ".env" });
 
 const MAX_ATTEMPTS = 20;
 const INTERVAL_MS = 5_000;
+const BODY_PREVIEW_CHARS = 500;
+const RESPONSE_HEADERS = [
+  "cache-control",
+  "content-length",
+  "content-type",
+  "date",
+  "server",
+  "via",
+  "x-amz-cf-id",
+  "x-amz-cf-pop",
+  "x-cache",
+  "x-request-id",
+];
+
+function responseHeaders(res) {
+  return Object.fromEntries(
+    RESPONSE_HEADERS.flatMap((header) => {
+      const value = res.headers.get(header);
+      return value ? [[header, value]] : [];
+    }),
+  );
+}
+
+async function responseBodyPreview(res) {
+  const contentType = res.headers.get("content-type") ?? "";
+
+  if (!contentType.match(/json|text|html|xml|plain/i)) {
+    return undefined;
+  }
+
+  const body = await res.text();
+
+  return body.length > BODY_PREVIEW_CHARS
+    ? `${body.slice(0, BODY_PREVIEW_CHARS)}...`
+    : body;
+}
+
+function logHealthcheck(event) {
+  console.log(`healthcheck_response ${JSON.stringify(event)}`);
+}
 
 export default async function globalSetup() {
   const baseUrl = process.env.BASE_URL;
@@ -19,21 +59,41 @@ export default async function globalSetup() {
   const healthUrl = `${baseUrl}/healthcheck`;
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const startedAt = Date.now();
+
     try {
       const res = await fetch(healthUrl);
+      const event = {
+        timestamp: new Date().toISOString(),
+        attempt,
+        maxAttempts: MAX_ATTEMPTS,
+        url: healthUrl,
+        ok: res.ok,
+        status: res.status,
+        statusText: res.statusText,
+        durationMs: Date.now() - startedAt,
+        headers: responseHeaders(res),
+        bodyPreview: await responseBodyPreview(res),
+      };
+
+      logHealthcheck(event);
 
       if (res.ok) {
-        console.log(`Service ready at ${healthUrl} (attempt ${attempt})`);
         return;
       }
-
-      console.log(
-        `Health check returned ${res.status} (attempt ${attempt}/${MAX_ATTEMPTS})`,
-      );
     } catch (err) {
-      console.log(
-        `Health check failed: ${err.message} (attempt ${attempt}/${MAX_ATTEMPTS})`,
-      );
+      logHealthcheck({
+        timestamp: new Date().toISOString(),
+        attempt,
+        maxAttempts: MAX_ATTEMPTS,
+        url: healthUrl,
+        ok: false,
+        durationMs: Date.now() - startedAt,
+        error: {
+          name: err.name,
+          message: err.message,
+        },
+      });
     }
 
     if (attempt < MAX_ATTEMPTS) {


### PR DESCRIPTION
## What

Adds structured logging for production healthcheck polling in Playwright global setup. Each attempt now emits a `healthcheck_response` JSON line with status, duration, selected CloudFront/application headers, and a short text body preview.

Also adds Dependabot version update configuration for GitHub Actions and npm dependencies, both on a weekly schedule with a 7 day cooldown.

## Why

The production e2e suite can fail before tests start when the public `/healthcheck` probe receives an edge-layer response. The extra response metadata should make future failures easier to correlate with CloudFront/WAF and application logs.
