### PR TITLE
BAU: Update slack webhook secret name

### DIFF
--- a/.github/workflows/check-production.yml
+++ b/.github/workflows/check-production.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Slack notification
         uses: trade-tariff/trade-tariff-tools/.github/actions/slack-notify@main
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK }}
           username: GitHub
           channel: production-alerts
           color: failure


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- [x] Changed Slack webhook name from `SLACK_WEBHOOK_URL` to `SLACK_WEBHOOK`

## Why?

I am doing this because:

- `SLACK_WEBHOOK_URL` is duplicating `SLACK_WEBHOOK` secret
