### PR TITLE
Fix Playwright tests after dynamic search input ID change

### DIFF
--- a/tests/find-commodity.spec.js
+++ b/tests/find-commodity.spec.js
@@ -4,16 +4,16 @@ import LoginPage from "../pages/loginPage.js";
 test.describe("Find Commodity", () => {
   test("searching commodity by reference", async ({ page }) => {
     await new LoginPage("/find_commodity", page).login();
-    await page.locator("#q").fill("ricotta");
-    await page.locator("#q").press("Enter");
+    await page.locator('input[role="combobox"]').fill("ricotta");
+    await page.locator('input[role="combobox"]').press("Enter");
 
     expect(page.url()).toContain("/commodities/0406105090");
   });
 
   test("searching commodity by code", async ({ page }) => {
     await new LoginPage("/find_commodity", page).login();
-    await page.locator("#q").fill("1701991000");
-    await page.locator("#q").press("Enter");
+    await page.locator('input[role="combobox"]').fill("1701991000");
+    await page.locator('input[role="combobox"]').press("Enter");
 
     expect(page.url()).toContain("/commodities/1701991000");
 


### PR DESCRIPTION
# Jira link

BAU

### What
Updated Playwright tests to replace the `#q` selector with `input[role="combobox"]`.

### Why
The frontend changed the search input to use a dynamic ID (`<%= input_id %>`), which made the static `#q` selector invalid and caused test timeouts.

Using a role-based selector ensures the tests remain stable and not dependent on dynamically generated IDs.

### Impact
- Fixes failing E2E tests in CI
- Improves selector resilience against future UI changes