### PR TITLE
Send WAF bypass header from Playwright and wire production workflow secret

### DIFF
--- a/.github/workflows/check-production.yml
+++ b/.github/workflows/check-production.yml
@@ -1,5 +1,7 @@
 name: Check Production
 on:
+  schedule:
+    - cron: "*/10 * * * *"
   workflow_dispatch:
 
 jobs:
@@ -33,6 +35,8 @@ jobs:
     with:
       test-environment: production
       ref: ${{ github.sha }}
+    secrets:
+      waf_bypass_token: ${{ secrets.WAF_BYPASS_TOKEN }}
 
   on-failure:
     runs-on: ubuntu-latest

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -20,6 +20,9 @@ export default defineConfig({
   use: {
     trace: "off",
     baseURL: process.env.BASE_URL,
+    extraHTTPHeaders: process.env.WAF_BYPASS_TOKEN
+      ? { "x-waf-bypass": process.env.WAF_BYPASS_TOKEN }
+      : {},
   },
   timeout: 30 * 1000, // 30 seconds
   projects: [


### PR DESCRIPTION
# Jira link

[HMRC-\<TODO\>](https://transformuk.atlassian.net/browse/HMRC-<TODO>)

## What?

I have:

- [x] Added `extraHTTPHeaders` to `playwright.config.js` — when `WAF_BYPASS_TOKEN` is set, every Playwright request includes `X-WAF-Bypass: <token>`
- [x] Updated `check-production.yml` to pass `WAF_BYPASS_TOKEN` from GitHub Actions secrets to the shared e2e workflow

## Why?

I am doing this because:

- Bot Control (TARGETED + ML) on the production WAF correctly identifies Playwright as a bot and blocks its requests, causing 12 tests to time out waiting for elements that never render
- A companion PR in `trade-tariff-platform-aws-terraform` adds a WAF allow rule at priority 7 that matches the `X-WAF-Bypass` header and terminates evaluation before bot control (priority 70) runs
- A companion PR in `trade-tariff-tools` adds `waf_bypass_token` as an accepted secret in the shared workflow
- Once `WAF_BYPASS_TOKEN` is set as a GitHub Actions secret in this repository (matching the value deployed via `TF_VAR_waf_e2e_secret_token` in the terraform repo), CI traffic will bypass bot control while real user traffic remains fully protected

Companion PRs:
- trade-tariff-platform-aws-terraform#641 — WAF allow rule and variable
- trade-tariff-tools#156 — shared workflow accepts the secret