### PR TITLE
Send WAF bypass header from e2e tests

### DIFF
--- a/.github/workflows/check-production.yml
+++ b/.github/workflows/check-production.yml
@@ -36,7 +36,7 @@ jobs:
       test-environment: production
       ref: ${{ github.sha }}
     secrets:
-      waf_bypass_token: ${{ secrets.WAF_BYPASS_TOKEN }}
+      waf_bypass_token: ${{ secrets.TF_VAR_WAF_E2E_SECRET_TOKEN }}
 
   on-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -33,3 +33,4 @@ jobs:
       ref: ${{ github.sha }}
     secrets:
       basic_password: ${{ secrets.BASIC_PASSWORD }}
+      waf_bypass_token: ${{ secrets.TF_VAR_WAF_E2E_SECRET_TOKEN }}

--- a/global-setup.js
+++ b/global-setup.js
@@ -1,5 +1,6 @@
 import path from "path";
 import dotenv from "dotenv";
+import { wafBypassHeaders } from "./utils/wafBypassHeaders.js";
 
 const playwrightEnv = process.env.PLAYWRIGHT_ENV ?? "development";
 const envFile = path.resolve(__dirname, `.env.${playwrightEnv}`);
@@ -62,7 +63,7 @@ export default async function globalSetup() {
     const startedAt = Date.now();
 
     try {
-      const res = await fetch(healthUrl);
+      const res = await fetch(healthUrl, { headers: wafBypassHeaders() });
       const event = {
         timestamp: new Date().toISOString(),
         attempt,

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 import path from "path";
 import dotenv from "dotenv";
+import { wafBypassHeaders } from "./utils/wafBypassHeaders.js";
 
 const playwrightEnv = process.env.PLAYWRIGHT_ENV ?? "development";
 const envFile = path.resolve(__dirname, `.env.${playwrightEnv}`);
@@ -20,9 +21,7 @@ export default defineConfig({
   use: {
     trace: "off",
     baseURL: process.env.BASE_URL,
-    extraHTTPHeaders: process.env.WAF_BYPASS_TOKEN
-      ? { "x-waf-bypass": process.env.WAF_BYPASS_TOKEN }
-      : {},
+    extraHTTPHeaders: wafBypassHeaders(),
   },
   timeout: 30 * 1000, // 30 seconds
   projects: [

--- a/utils/wafBypassHeaders.js
+++ b/utils/wafBypassHeaders.js
@@ -1,0 +1,3 @@
+export function wafBypassHeaders(token = process.env.WAF_BYPASS_TOKEN) {
+  return token ? { "x-waf-bypass": token } : {};
+}

--- a/utils/wafBypassHeaders.test.js
+++ b/utils/wafBypassHeaders.test.js
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { wafBypassHeaders } from "./wafBypassHeaders.js";
+
+test("returns an empty header set when no WAF bypass token is configured", () => {
+  assert.deepEqual(wafBypassHeaders(), {});
+});
+
+test("returns the WAF bypass header when a token is configured", () => {
+  assert.deepEqual(wafBypassHeaders("secret-token"), {
+    "x-waf-bypass": "secret-token",
+  });
+});


### PR DESCRIPTION
## What changed

- Added a shared helper for the WAF bypass header.
- Reused the helper in Playwright `extraHTTPHeaders`.
- Sent the same header from `global-setup.js` healthcheck polling.
- Passed `secrets.TF_VAR_WAF_E2E_SECRET_TOKEN` into the development and production e2e workflow calls as `waf_bypass_token`.

## Why

The reusable workflow exposes `WAF_BYPASS_TOKEN`, but the e2e suite also needs to send `X-WAF-Bypass` on both the readiness healthcheck and browser/API requests.

## Risk

Low risk: the header is only sent when the optional secret is present.