### PR TITLE
Fix package.json name and repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "license": "MIT",
   "main": "index.js",
-  "name": "trade-tariff-fpo-dev-hub-e2e",
-  "repository": "git@github.com:trade-tariff/trade-tariff-fpo-dev-hub-e2e.git",
+  "name": "trade-tariff-e2e-tests",
+  "repository": "git@github.com:trade-tariff/trade-tariff-e2e-tests.git",
   "scripts": {
     "fix": "eslint . --ext .js --fix",
     "lint": "eslint . --ext .js",


### PR DESCRIPTION
### What?

I have added/removed/altered:

- [x] Fixed `name` and `repository` in `package.json` (were incorrectly copied from fpo-dev-hub-e2e)

### Why?

I am doing this because:

- The e2e repo metadata pointed at the wrong package/repo name
- Avoids confusion for tooling, Dependabot, and anyone cloning the repo
