### PR TITLE
test(admin-assets): add admin asset smoke coverage

### DIFF
--- a/tests/adminUI-assets.spec.js
+++ b/tests/adminUI-assets.spec.js
@@ -1,0 +1,25 @@
+import { test, expect } from "@playwright/test";
+import LoginPage from "../pages/loginPage.js";
+import { monitorAssetErrors } from "../utils/assetErrorMonitor.js";
+
+test.describe("Admin assets", () => {
+  test("classification configuration page loads JavaScript assets without errors", async ({
+    page,
+  }) => {
+    const assetErrorMonitor = monitorAssetErrors(page);
+
+    await new LoginPage(
+      `${process.env.ADMIN_URL}/classification_configurations`,
+      page,
+      true,
+    ).login();
+
+    await page.waitForLoadState("networkidle");
+
+    assetErrorMonitor.assertNoErrors();
+
+    await expect(
+      page.getByRole("heading", { name: "Classification Configurations" }),
+    ).toBeVisible();
+  });
+});

--- a/tests/adminUI-assets.spec.js
+++ b/tests/adminUI-assets.spec.js
@@ -3,23 +3,17 @@ import LoginPage from "../pages/loginPage.js";
 import { monitorAssetErrors } from "../utils/assetErrorMonitor.js";
 
 test.describe("Admin assets", () => {
-  test("classification configuration page loads JavaScript assets without errors", async ({
+  test("admin root loads JavaScript assets without errors", async ({
     page,
   }) => {
     const assetErrorMonitor = monitorAssetErrors(page);
 
-    await new LoginPage(
-      `${process.env.ADMIN_URL}/classification_configurations`,
-      page,
-      true,
-    ).login();
+    await new LoginPage(process.env.ADMIN_URL, page, true).login();
 
     await page.waitForLoadState("networkidle");
 
     assetErrorMonitor.assertNoErrors();
 
-    await expect(
-      page.getByRole("heading", { name: "Classification Configurations" }),
-    ).toBeVisible();
+    await expect(page.locator("body")).toBeVisible();
   });
 });

--- a/tests/frontend-assets.spec.js
+++ b/tests/frontend-assets.spec.js
@@ -1,0 +1,22 @@
+import { test, expect } from "@playwright/test";
+import LoginPage from "../pages/loginPage.js";
+import { monitorAssetErrors } from "../utils/assetErrorMonitor.js";
+
+test.describe("Frontend assets", () => {
+  test("find commodity page loads JavaScript assets without errors", async ({
+    page,
+  }) => {
+    const assetErrorMonitor = monitorAssetErrors(page);
+
+    await new LoginPage("/find_commodity", page).login();
+    await page.waitForLoadState("networkidle");
+
+    assetErrorMonitor.assertNoErrors();
+
+    await expect(
+      page.getByRole("heading", {
+        name: "Look up commodity codes, import duties, taxes and controls",
+      }),
+    ).toBeVisible();
+  });
+});

--- a/utils/assetErrorMonitor.js
+++ b/utils/assetErrorMonitor.js
@@ -2,23 +2,28 @@ import { expect } from "@playwright/test";
 
 export function monitorAssetErrors(page) {
   const assetFailures = [];
-  const consoleErrors = [];
+  const assetConsoleErrors = [];
   const pageErrors = [];
+  const assetPathPattern = /\/(assets|javascripts)\//;
 
   page.on("response", (response) => {
     const url = response.url();
 
-    if (
-      response.status() >= 400 &&
-      (url.includes("/assets/") || url.includes("/javascripts/"))
-    ) {
+    if (response.status() >= 400 && assetPathPattern.test(url)) {
       assetFailures.push(`${response.status()} ${url}`);
     }
   });
 
   page.on("console", (message) => {
-    if (message.type() === "error") {
-      consoleErrors.push(message.text());
+    const text = message.text();
+
+    if (
+      message.type() === "error" &&
+      (assetPathPattern.test(text) ||
+        (text.includes("Failed to load resource") &&
+          assetPathPattern.test(message.location().url)))
+    ) {
+      assetConsoleErrors.push(text);
     }
   });
 
@@ -29,7 +34,7 @@ export function monitorAssetErrors(page) {
   return {
     assertNoErrors() {
       expect(assetFailures).toEqual([]);
-      expect(consoleErrors).toEqual([]);
+      expect(assetConsoleErrors).toEqual([]);
       expect(pageErrors).toEqual([]);
     },
   };

--- a/utils/assetErrorMonitor.js
+++ b/utils/assetErrorMonitor.js
@@ -1,0 +1,36 @@
+import { expect } from "@playwright/test";
+
+export function monitorAssetErrors(page) {
+  const assetFailures = [];
+  const consoleErrors = [];
+  const pageErrors = [];
+
+  page.on("response", (response) => {
+    const url = response.url();
+
+    if (
+      response.status() >= 400 &&
+      (url.includes("/assets/") || url.includes("/javascripts/"))
+    ) {
+      assetFailures.push(`${response.status()} ${url}`);
+    }
+  });
+
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      consoleErrors.push(message.text());
+    }
+  });
+
+  page.on("pageerror", (error) => {
+    pageErrors.push(error.message);
+  });
+
+  return {
+    assertNoErrors() {
+      expect(assetFailures).toEqual([]);
+      expect(consoleErrors).toEqual([]);
+      expect(pageErrors).toEqual([]);
+    },
+  };
+}


### PR DESCRIPTION
# Jira link

[HMRC-2466](https://transformuk.atlassian.net/browse/HMRC-2466)

## What?

I have:

- [x] Added shared asset error monitoring for E2E browser tests
- [x] Added an admin asset smoke test for the admin root URL
- [x] Added a frontend asset smoke test for `/find_commodity`
- [ ] Removed

## Why?

I am doing this because:

- Admin pages currently have broken GOV.UK Frontend asset requests that show up as browser console 404s.
- The pre-release E2E suite should fail when an admin or frontend page returns 4xx/5xx responses for JavaScript or CSS assets under `/assets/` or `/javascripts/`.
- The admin smoke uses the admin root URL so it is not tied to a deeper page behind app auth.
- The frontend smoke uses `/find_commodity` because the production frontend root redirects to another site.
- This coverage should catch regressions like missing GOV.UK Frontend `.mjs` modules before they reach production.

## Risk

Low risk. This adds test coverage only and does not change production application behaviour.

## Verification

- `direnv exec . yarn lint`
- `direnv exec . env PLAYWRIGHT_ENV=staging yarn playwright test tests/frontend-assets.spec.js --project=chromium`
- `direnv exec . env PLAYWRIGHT_ENV=development yarn playwright test tests/adminUI-assets.spec.js tests/frontend-assets.spec.js --project=chromium`
- `direnv exec . yarn run test-development` currently runs the new asset smoke tests successfully, but the full suite is not green because existing admin navigation tests time out waiting for links such as `Switch to XI service`, `Search references`, and `Updates`.

The admin PR full development deployment completed the admin deploy, then the shared E2E gate failed in an existing frontend quota test: `tests/quota-search.spec.js` timed out waiting for `Albania (AL)`. That run did not execute admin checks because `SKIP_ADMIN=true`, so the targeted dev command above is the direct proof for this asset smoke coverage.