### PR TITLE
HMRC-2468: Assert autocomplete suggestions while typing

### DIFF
--- a/tests/find-commodity.spec.js
+++ b/tests/find-commodity.spec.js
@@ -21,4 +21,33 @@ test.describe("Find Commodity", () => {
     await quotaMeasure.first().scrollIntoViewIfNeeded();
     await expect(quotaMeasure.first()).toBeVisible();
   });
+
+  // Guards against regressions where autocomplete init fails (e.g. debounce@3
+  // rejecting a boolean third argument) and falls back to a plain text input
+  // with no suggestion list.
+  test("shows accessible autocomplete suggestions while typing", async ({
+    page,
+  }) => {
+    await new LoginPage("/find_commodity", page).login();
+
+    const keywordSearch = page.getByRole("radio", {
+      name: "Keyword or commodity code search",
+    });
+    if (await keywordSearch.count()) {
+      await keywordSearch.check();
+    }
+
+    const searchInput = page.locator('input[role="combobox"]');
+    await expect(searchInput).toBeVisible();
+
+    await searchInput.click();
+    await searchInput.pressSequentially("tomato", { delay: 40 });
+
+    await expect(
+      page.getByRole("listbox").getByRole("option").first(),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.getByRole("option", { name: /tomato/i }).first(),
+    ).toBeVisible();
+  });
 });


### PR DESCRIPTION
### Jira link

[HMRC-2468](https://transformuk.atlassian.net/browse/HMRC-2468)

### What?

- [x] Add a small Playwright assertion that Find commodity shows accessible autocomplete suggestions while typing

### Why?

Commodity search autocomplete can fail silently when JS init throws (for example after the debounce@3 upgrade, which rejected a boolean third argument and fell back to a plain text input). Existing find-commodity tests type into a combobox and submit, but do not check that the suggestion list appears.

This test fails if:

- enhanced autocomplete does not initialise (`input[role=combobox]` missing)
- the suggestion listbox does not populate while typing

Verified locally against the frontend fix (`BASE_URL=http://localhost:3001`). Currently fails on **dev** until [frontend#3216](https://github.com/trade-tariff/trade-tariff-frontend/pull/3216) is deployed — that is expected and proves the regression is covered.

### Ticket

[HMRC-2468](https://transformuk.atlassian.net/browse/HMRC-2468)

### Risk

**Risk level:** 🟢

**Reason for rating:** Tests-only change adding coverage for existing search UI behaviour.