### PR TITLE
HMRC-2469: verify exchange rate CSVs via request and table cross-check

### DIFF
--- a/tests/validate-exchange-rates.spec.js
+++ b/tests/validate-exchange-rates.spec.js
@@ -1,6 +1,52 @@
 import { test, expect } from "@playwright/test";
 import LoginPage from "../pages/loginPage.js";
 import DownloadHelper from "../utils/downloadHelper.js";
+import { assertExchangeRateCsv } from "../utils/exchangeRateCsv.js";
+
+const SAMPLE_CODES = ["EUR", "USD", "JPY"];
+
+/**
+ * Read major currency rates from the online table so the CSV can be
+ * cross-checked against the same page the user sees.
+ */
+async function sampleRatesFromTable(page, codes = SAMPLE_CODES) {
+  const rows = await page.locator("table tbody tr").evaluateAll((trs) =>
+    trs.map((tr) => {
+      const cells = [...tr.querySelectorAll("td")].map((td) =>
+        td.textContent.replace(/\s+/g, " ").trim(),
+      );
+      return {
+        code: cells[2] ?? "",
+        rate: cells[3] ?? "",
+      };
+    }),
+  );
+
+  const samples = {};
+  for (const code of codes) {
+    const match = rows.find((row) => row.code === code);
+    expect(match, `online table missing ${code}`).toBeTruthy();
+    expect(match.rate, `online table missing rate for ${code}`).toBeTruthy();
+    samples[code] = match.rate;
+  }
+  return samples;
+}
+
+async function assertCsvMatchesTable(page, breadcrumbName, sampleRates) {
+  await page
+    .getByRole("link", { name: breadcrumbName })
+    .click({ timeout: 20000 });
+  await DownloadHelper.downloadAndVerify(
+    page,
+    page.getByRole("link", { name: /CSV\s+\d+\.?\d*\s*KB/ }).first(),
+    /\.csv$/i,
+    {
+      assertBody: (body) => {
+        assertExchangeRateCsv(body, sampleRates);
+      },
+    },
+  );
+}
 
 test.describe("Exchange Rates", () => {
   test("Validating monthly exchange rates", async ({ page }) => {
@@ -9,13 +55,9 @@ test.describe("Exchange Rates", () => {
     await expect(
       page.getByRole("columnheader", { name: "Country/territory" }),
     ).toBeVisible({ timeout: 20000 });
-    await page
-      .getByRole("link", { name: "Monthly exchange rates" })
-      .click({ timeout: 20000 });
-    await DownloadHelper.downloadAndVerify(
-      page,
-      page.getByRole("link", { name: /CSV\s+\d+\.?\d*\s*KB/ }).first(),
-    );
+
+    const sampleRates = await sampleRatesFromTable(page);
+    await assertCsvMatchesTable(page, "Monthly exchange rates", sampleRates);
   });
 
   test("Validating average exchange rates", async ({ page }) => {
@@ -27,13 +69,9 @@ test.describe("Exchange Rates", () => {
     await expect(
       page.getByRole("columnheader", { name: "Country/territory" }),
     ).toBeVisible({ timeout: 20000 });
-    await page
-      .getByRole("link", { name: "Average exchange rates" })
-      .click({ timeout: 20000 });
-    await DownloadHelper.downloadAndVerify(
-      page,
-      page.getByRole("link", { name: /CSV\s+\d+\.?\d*\s*KB/ }).first(),
-    );
+
+    const sampleRates = await sampleRatesFromTable(page);
+    await assertCsvMatchesTable(page, "Average exchange rates", sampleRates);
   });
 
   test("Validating spot exchange rates", async ({ page }) => {
@@ -45,10 +83,8 @@ test.describe("Exchange Rates", () => {
     await expect(
       page.getByRole("columnheader", { name: "Country/territory" }),
     ).toBeVisible({ timeout: 20000 });
-    await page.getByRole("link", { name: "Spot exchange rates" }).click();
-    await DownloadHelper.downloadAndVerify(
-      page,
-      page.getByRole("link", { name: /CSV\s+\d+\.?\d*\s*KB/ }).first(),
-    );
+
+    const sampleRates = await sampleRatesFromTable(page);
+    await assertCsvMatchesTable(page, "Spot exchange rates", sampleRates);
   });
 });

--- a/utils/downloadHelper.js
+++ b/utils/downloadHelper.js
@@ -1,18 +1,106 @@
 import { expect } from "@playwright/test";
 
+/**
+ * Prefer an authenticated request over Playwright's "download" event.
+ * Exchange-rate files redirect (app → API → signed S3). That multi-hop
+ * attachment path often never fires page.waitForEvent("download") within
+ * short CI timeouts, which flakes staging/prod deploys.
+ */
+export function filenameFromDisposition(disposition, finalUrl, originalUrl) {
+  const star = disposition.match(/filename\*=UTF-8''([^;]+)/i);
+  if (star?.[1]) {
+    return decodeURIComponent(star[1].trim());
+  }
+
+  const plain = disposition.match(/filename="?([^";]+)"?/i);
+  if (plain?.[1]) {
+    return plain[1].trim();
+  }
+
+  for (const candidate of [finalUrl, originalUrl]) {
+    try {
+      const leaf = new URL(candidate).pathname.split("/").pop();
+      if (leaf) {
+        return decodeURIComponent(leaf);
+      }
+    } catch {
+      // ignore invalid URL
+    }
+  }
+
+  return "";
+}
+
 export default class DownloadHelper {
+  /**
+   * @param {import('@playwright/test').Page} page
+   * @param {import('@playwright/test').Locator} linkLocator
+   * @param {RegExp} [filenamePattern]
+   * @param {{
+   *   timeout?: number,
+   *   assertBody?: (body: Buffer, meta: { filename: string, url: string, finalUrl: string }) => void | Promise<void>,
+   * }} [options]
+   */
   static async downloadAndVerify(
     page,
     linkLocator,
     filenamePattern = /\.csv$/i,
-    options = { timeout: 10000 },
+    options = {},
   ) {
+    const timeout = options.timeout ?? 30_000;
+    const assertBody = options.assertBody;
+
     await expect(linkLocator).toBeVisible();
-    const downloadPromise = page.waitForEvent("download", options);
-    await linkLocator.click();
-    const download = await downloadPromise;
-    expect(download.suggestedFilename()).toMatch(filenamePattern);
-    expect(await download.failure()).toBeNull();
-    return download;
+
+    const href = await linkLocator.getAttribute("href");
+    expect(href, "download link should have an href").toBeTruthy();
+
+    const absoluteUrl = new URL(href, page.url()).toString();
+    const response = await page.request.get(absoluteUrl, {
+      timeout,
+      maxRedirects: 10,
+    });
+
+    expect(
+      response.ok(),
+      `download request failed: ${response.status()} for ${absoluteUrl}`,
+    ).toBeTruthy();
+
+    const headers = response.headers();
+    const contentType = headers["content-type"] ?? "";
+    expect(
+      contentType.includes("text/html"),
+      `expected a file download but received HTML (${contentType}) from ${absoluteUrl} (final: ${response.url()})`,
+    ).toBe(false);
+
+    const body = Buffer.from(await response.body());
+    expect(
+      body.byteLength,
+      `download body was empty for ${absoluteUrl}`,
+    ).toBeGreaterThan(0);
+
+    const disposition = headers["content-disposition"] ?? "";
+    const filename = filenameFromDisposition(
+      disposition,
+      response.url(),
+      absoluteUrl,
+    );
+    expect(filename).toMatch(filenamePattern);
+
+    if (assertBody) {
+      await assertBody(body, {
+        filename,
+        url: absoluteUrl,
+        finalUrl: response.url(),
+      });
+    }
+
+    return {
+      body,
+      filename,
+      response,
+      suggestedFilename: () => filename,
+      failure: async () => null,
+    };
   }
 }

--- a/utils/downloadHelper.test.js
+++ b/utils/downloadHelper.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { filenameFromDisposition } from "./downloadHelper.js";
+
+test("extracts RFC 5987 filename from content-disposition", () => {
+  assert.equal(
+    filenameFromDisposition(
+      "attachment; filename*=UTF-8''exrates-monthly-0726.csv",
+      "https://example.com/x",
+      "https://example.com/y",
+    ),
+    "exrates-monthly-0726.csv",
+  );
+});
+
+test("extracts quoted filename from content-disposition", () => {
+  assert.equal(
+    filenameFromDisposition(
+      'attachment; filename="exrates-monthly-0726.csv"',
+      "https://example.com/x",
+      "https://example.com/y",
+    ),
+    "exrates-monthly-0726.csv",
+  );
+});
+
+test("falls back to final URL path when disposition is missing", () => {
+  assert.equal(
+    filenameFromDisposition(
+      "",
+      "https://s3.example.com/data/monthly_csv_2026-7.csv?X-Amz-Signature=abc",
+      "https://www.example.com/exchange_rates/view/files/monthly_csv_2026-7.csv",
+    ),
+    "monthly_csv_2026-7.csv",
+  );
+});

--- a/utils/exchangeRateCsv.js
+++ b/utils/exchangeRateCsv.js
@@ -1,0 +1,106 @@
+/**
+ * Lightweight exchange-rate CSV checks for e2e.
+ * Monthly, average, and spot files share Currency Code + rate columns but
+ * differ on other headers.
+ */
+
+const REQUIRED_HEADERS = ["Currency Code", "Currency Units per £1"];
+
+export function parseExchangeRateCsv(text) {
+  const lines = text
+    .replace(/^\uFEFF/, "")
+    .trim()
+    .split(/\r?\n/)
+    .filter((line) => line.length > 0);
+
+  if (lines.length < 2) {
+    throw new Error(`CSV has too few lines (${lines.length})`);
+  }
+
+  const headers = splitCsvLine(lines[0]);
+  const rows = lines.slice(1).map((line, index) => {
+    const cells = splitCsvLine(line);
+    if (cells.length !== headers.length) {
+      throw new Error(
+        `CSV row ${index + 2} has ${cells.length} columns, expected ${headers.length}`,
+      );
+    }
+    return Object.fromEntries(headers.map((header, i) => [header, cells[i]]));
+  });
+
+  return { headers, rows };
+}
+
+function splitCsvLine(line) {
+  // HMRC exchange-rate CSVs are unquoted simple fields.
+  return line.split(",").map((cell) => cell.trim());
+}
+
+/**
+ * @param {string|Buffer|Uint8Array} body
+ * @param {Record<string, string>} [sampleRates] currency code → rate string from the online table
+ * @param {{ minRows?: number }} [options]
+ */
+export function assertExchangeRateCsv(body, sampleRates = {}, options = {}) {
+  const minRows = options.minRows ?? 5;
+  const text = Buffer.isBuffer(body)
+    ? body.toString("utf8")
+    : typeof body === "string"
+      ? body
+      : Buffer.from(body).toString("utf8");
+
+  if (/<!DOCTYPE html|<html[\s>]/i.test(text)) {
+    throw new Error("Expected CSV file but body looks like HTML");
+  }
+
+  const { headers, rows } = parseExchangeRateCsv(text);
+
+  for (const required of REQUIRED_HEADERS) {
+    if (!headers.includes(required)) {
+      throw new Error(
+        `CSV missing required header "${required}". Got: ${headers.join(", ")}`,
+      );
+    }
+  }
+
+  if (rows.length < minRows) {
+    throw new Error(
+      `CSV has only ${rows.length} data rows; expected at least ${minRows}`,
+    );
+  }
+
+  for (const row of rows) {
+    const rate = Number(row["Currency Units per £1"]);
+    if (!Number.isFinite(rate) || rate <= 0) {
+      throw new Error(
+        `Invalid rate for ${row["Currency Code"]}: ${row["Currency Units per £1"]}`,
+      );
+    }
+  }
+
+  for (const [code, expectedRate] of Object.entries(sampleRates)) {
+    if (expectedRate == null || expectedRate === "") {
+      throw new Error(`Missing sample rate for ${code} from online table`);
+    }
+    const match = rows.find((row) => row["Currency Code"] === code);
+    if (!match) {
+      throw new Error(`CSV missing currency code ${code}`);
+    }
+    // Online table can show fewer decimal places than the file in edge cases;
+    // compare numeric values rather than raw strings.
+    const expected = Number(expectedRate);
+    const actual = Number(match["Currency Units per £1"]);
+    if (!Number.isFinite(expected) || !Number.isFinite(actual)) {
+      throw new Error(
+        `Non-numeric rate for ${code}: online=${expectedRate}, csv=${match["Currency Units per £1"]}`,
+      );
+    }
+    if (Math.abs(expected - actual) > 0.00005) {
+      throw new Error(
+        `CSV rate mismatch for ${code}: online table=${expectedRate}, csv=${match["Currency Units per £1"]}`,
+      );
+    }
+  }
+
+  return { headers, rows };
+}

--- a/utils/exchangeRateCsv.test.js
+++ b/utils/exchangeRateCsv.test.js
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  assertExchangeRateCsv,
+  parseExchangeRateCsv,
+} from "./exchangeRateCsv.js";
+
+const SAMPLE_CSV = `Country/Territories,Currency,Currency Code,Currency Units per £1,Start date,End date
+Eurozone,Euro,EUR,1.1564,01/07/2026,31/07/2026
+USA,Dollar,USD,1.3404,01/07/2026,31/07/2026
+Japan,Yen,JPY,214.8908,01/07/2026,31/07/2026
+`;
+
+// pad to satisfy minRows in unit tests via option override
+function paddedCsv(extraRows = 50) {
+  const lines = [SAMPLE_CSV.trim()];
+  for (let i = 0; i < extraRows; i += 1) {
+    lines.push(
+      `Country${i},Cur${i},C${i},${(i + 1).toFixed(4)},01/07/2026,31/07/2026`,
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+test("parseExchangeRateCsv reads headers and rows", () => {
+  const { headers, rows } = parseExchangeRateCsv(SAMPLE_CSV);
+  assert.equal(headers[2], "Currency Code");
+  assert.equal(rows.length, 3);
+  assert.equal(rows[0]["Currency Code"], "EUR");
+  assert.equal(rows[0]["Currency Units per £1"], "1.1564");
+});
+
+test("assertExchangeRateCsv accepts valid file and matching samples", () => {
+  const { rows } = assertExchangeRateCsv(
+    paddedCsv(),
+    {
+      EUR: "1.1564",
+      USD: "1.3404",
+      JPY: "214.8908",
+    },
+    { minRows: 50 },
+  );
+  assert.ok(rows.length >= 50);
+});
+
+test("assertExchangeRateCsv rejects rate mismatch vs online samples", () => {
+  assert.throws(
+    () =>
+      assertExchangeRateCsv(paddedCsv(), { EUR: "9.9999" }, { minRows: 50 }),
+    /CSV rate mismatch for EUR/,
+  );
+});
+
+test("assertExchangeRateCsv rejects HTML bodies", () => {
+  assert.throws(
+    () =>
+      assertExchangeRateCsv("<!DOCTYPE html><html></html>", {}, { minRows: 1 }),
+    /looks like HTML/,
+  );
+});
+
+test("assertExchangeRateCsv rejects non-positive rates", () => {
+  const bad = `Country/Territories,Currency,Currency Code,Currency Units per £1,Start date,End date
+Eurozone,Euro,EUR,0,01/07/2026,31/07/2026
+`;
+  assert.throws(
+    () => assertExchangeRateCsv(bad, {}, { minRows: 1 }),
+    /Invalid rate for EUR/,
+  );
+});


### PR DESCRIPTION
# Jira link

[HMRC-2469](https://transformuk.atlassian.net/browse/HMRC-2469)

## What?

I have:

- [x] Added request-based CSV download verification (no Playwright `download` event)
- [x] Added CSV structure checks and EUR/USD/JPY cross-check against the online table
- [x] Added unit tests for filename parsing and CSV assertions
- [x] Updated monthly, average, and spot exchange-rate e2e specs to use the new helper path
- [x] Removed reliance on flaky multi-hop browser download events for these files

## Why?

I am doing this because:

- Staging deploys and production canary runs have been going red on exchange-rate e2e even when the service and rate files are fine
- The tests wait for Playwright’s `download` event on multi-hop app → API → signed S3 attachments, which often never fires within the CI timeout
- Release health should reflect real problems, not download-event flakes; checks should still prove the CSV content matches the online table

## Risk

**Risk level:** 🟢

**Reason for rating:** Test-only change in the e2e suite. No production app behaviour change. Makes existing coverage more reliable and more rigorous.

## Test plan

- [x] `node --test utils/downloadHelper.test.js utils/exchangeRateCsv.test.js`
- [x] eslint + prettier
- [ ] PR CI green
- [ ] After merge, re-run a previously failing backend staging e2e