### PR TITLE
Speed up robust E2E browser journeys

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -24,6 +24,7 @@ jobs:
             ${{ runner.os }}-pre-commit-
       - run: pip install pre-commit
       - run: npm install -g yarn && yarn
+      - run: yarn test-unit
       - run: pre-commit run --all-files
 
   run-tests:

--- a/fixtures.js
+++ b/fixtures.js
@@ -1,0 +1,61 @@
+import { expect, test as base } from "@playwright/test";
+
+import { createAuthenticatedState } from "./utils/authState.js";
+import { wafBypassHeaders } from "./utils/wafBypassHeaders.js";
+
+const EMPTY_STORAGE_STATE = { cookies: [], origins: [] };
+const isProduction = /www\.trade-tariff\.service\.gov\.uk/.test(
+  process.env.BASE_URL ?? "",
+);
+
+function createAuthenticatedTest({ enabled, baseURL, url }) {
+  const workerStorageState = enabled
+    ? [
+        async ({ browser }, use) => {
+          const state = await createAuthenticatedState(browser, {
+            enabled: true,
+            baseURL,
+            url,
+            password: process.env.BASIC_PASSWORD,
+            extraHTTPHeaders: wafBypassHeaders(),
+          });
+          await use(state);
+        },
+        { scope: "worker" },
+      ]
+    : [
+        async ({ browserName }, use) => {
+          void browserName;
+          await use(EMPTY_STORAGE_STATE);
+        },
+        { scope: "worker" },
+      ];
+
+  return base.extend({
+    storageState: async ({ workerStorageState }, use) => {
+      await use(workerStorageState);
+    },
+    workerStorageState,
+  });
+}
+
+export const test = createAuthenticatedTest({
+  enabled:
+    !isProduction &&
+    process.env.SKIP_FRONTEND !== "true" &&
+    Boolean(process.env.BASIC_PASSWORD),
+  baseURL: process.env.BASE_URL,
+  url: "/find_commodity",
+});
+
+export const adminTest = createAuthenticatedTest({
+  enabled:
+    !isProduction &&
+    process.env.SKIP_ADMIN !== "true" &&
+    Boolean(process.env.ADMIN_URL) &&
+    Boolean(process.env.BASIC_PASSWORD),
+  baseURL: process.env.ADMIN_URL,
+  url: process.env.ADMIN_URL,
+});
+
+export { expect };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test": "playwright test --workers 2",
     "test-development": "PLAYWRIGHT_ENV=development playwright test",
     "test-production": "PLAYWRIGHT_ENV=production playwright test",
-    "test-staging": "PLAYWRIGHT_ENV=staging playwright test"
+    "test-staging": "PLAYWRIGHT_ENV=staging playwright test",
+    "test-unit": "node --test utils/*.test.js pages/*.test.js"
   },
   "version": "1.0.0"
 }

--- a/pages/subscriptionPage.js
+++ b/pages/subscriptionPage.js
@@ -3,6 +3,9 @@ import EmailFetcher from "../utils/emailFetcher.js";
 import S3Lock from "../utils/s3Lock.js";
 
 import { expect } from "@playwright/test";
+import { setTimeout as sleep } from "node:timers/promises";
+
+const EMAIL_POLL_DELAYS_MS = [250, 250, 500, 500, 1000];
 
 export default class SubscribePage {
   constructor(page) {
@@ -20,15 +23,13 @@ export default class SubscribePage {
       process.env.PASSWORDLESS_POOL_NAME,
       process.env.AWS_DEFAULT_REGION,
     );
+    this.sleep = sleep;
   }
 
   async start() {
     // Acquire lock to ensure no other tests are running concurrently
     await this.locker.withLock(async () => {
       await this.cleaner.deleteUserByEmail(this.email_address);
-
-      // Sleep 1 second to ensure the user is deleted before proceeding
-      await new Promise((resolve) => setTimeout(resolve, 1000));
 
       // Navigate through subscription verification flow
       await this.click(this.startNowButton());
@@ -66,6 +67,7 @@ export default class SubscribePage {
 
     this.startTime = Date.now();
     this.email = undefined;
+    let poll = 0;
 
     while (Date.now() - this.startTime < timeout) {
       const email = await this.fetcher.getLatestEmail();
@@ -75,7 +77,10 @@ export default class SubscribePage {
         break;
       }
 
-      await new Promise((resolve) => setTimeout(resolve, 1 * 1000));
+      const delay =
+        EMAIL_POLL_DELAYS_MS[Math.min(poll, EMAIL_POLL_DELAYS_MS.length - 1)];
+      await this.sleep(delay);
+      poll += 1;
     }
     if (this.email) return this.email;
 

--- a/pages/subscriptionPage.test.js
+++ b/pages/subscriptionPage.test.js
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import SubscriptionPage from "./subscriptionPage.js";
+
+test("polls quickly for the first incoming email retry", async () => {
+  const delays = [];
+  const email = {
+    code: ["123456"],
+    send_date: new Date(Date.now() + 1_000),
+  };
+  const responses = [undefined, email];
+  const subscriptionPage = Object.create(SubscriptionPage.prototype);
+  subscriptionPage.fetcher = {
+    async getLatestEmail() {
+      return responses.shift();
+    },
+  };
+  subscriptionPage.sleep = async (duration) => delays.push(duration);
+
+  const result = await subscriptionPage.waitForEmail();
+
+  assert.equal(result, email);
+  assert.deepEqual(delays, [250]);
+});

--- a/tests/adminUI-assets.spec.js
+++ b/tests/adminUI-assets.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { adminTest as test, expect } from "../fixtures.js";
 import LoginPage from "../pages/loginPage.js";
 import { monitorAssetErrors } from "../utils/assetErrorMonitor.js";
 
@@ -9,11 +9,10 @@ test.describe("Admin assets", () => {
     const assetErrorMonitor = monitorAssetErrors(page);
 
     await new LoginPage(process.env.ADMIN_URL, page, true).login();
-
-    await page.waitForLoadState("networkidle");
-
-    assetErrorMonitor.assertNoErrors();
+    await page.waitForLoadState("load");
 
     await expect(page.locator("body")).toBeVisible();
+
+    assetErrorMonitor.assertNoErrors();
   });
 });

--- a/tests/adminUI-notes-nav.spec.js
+++ b/tests/adminUI-notes-nav.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { adminTest as test, expect } from "../fixtures.js";
 import LoginPage from "../pages/loginPage.js";
 
 test.describe("Notes", () => {

--- a/tests/adminUI-search-refs.spec.js
+++ b/tests/adminUI-search-refs.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { adminTest as test, expect } from "../fixtures.js";
 import LoginPage from "../pages/loginPage.js";
 
 test.describe("Search References", () => {

--- a/tests/adminUI-update-nav.spec.js
+++ b/tests/adminUI-update-nav.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { adminTest as test, expect } from "../fixtures.js";
 import LoginPage from "../pages/loginPage.js";
 
 test.describe("Admin updates", () => {

--- a/tests/api-endpoints.spec.js
+++ b/tests/api-endpoints.spec.js
@@ -1,5 +1,5 @@
 import Jsona from "jsona";
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures.js";
 import { validateApi } from "../utils/validateApi";
 
 const apiPaths = [

--- a/tests/browse-tariff.spec.js
+++ b/tests/browse-tariff.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures.js";
 import LoginPage from "../pages/loginPage.js";
 
 test.describe("Browse Page", () => {

--- a/tests/find-commodity.spec.js
+++ b/tests/find-commodity.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures.js";
 import LoginPage from "../pages/loginPage.js";
 
 test.describe("Find Commodity", () => {

--- a/tests/frontend-assets.spec.js
+++ b/tests/frontend-assets.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures.js";
 import LoginPage from "../pages/loginPage.js";
 import { monitorAssetErrors } from "../utils/assetErrorMonitor.js";
 
@@ -9,14 +9,14 @@ test.describe("Frontend assets", () => {
     const assetErrorMonitor = monitorAssetErrors(page);
 
     await new LoginPage("/find_commodity", page).login();
-    await page.waitForLoadState("networkidle");
-
-    assetErrorMonitor.assertNoErrors();
+    await page.waitForLoadState("load");
 
     await expect(
       page.getByRole("heading", {
         name: "Look up commodity codes, import duties, taxes and controls",
       }),
     ).toBeVisible();
+
+    assetErrorMonitor.assertNoErrors();
   });
 });

--- a/tests/navigation-a-to-z-tariff.spec.js
+++ b/tests/navigation-a-to-z-tariff.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures.js";
 import LoginPage from "../pages/loginPage.js";
 
 test.describe("A-Z Navigation", () => {

--- a/tests/quota-search.spec.js
+++ b/tests/quota-search.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures.js";
 import LoginPage from "../pages/loginPage.js";
 
 test.describe("Search for quotas", () => {

--- a/tests/rules-of-origin-display.spec.js
+++ b/tests/rules-of-origin-display.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures.js";
 import LoginPage from "../pages/loginPage.js";
 
 test.describe("Rules of origin Display", () => {

--- a/tests/subscribe.spec.js
+++ b/tests/subscribe.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures.js";
 import SubscriptionPage from "../pages/subscriptionPage.js";
 import LoginPage from "../pages/loginPage.js";
 

--- a/tests/validate-duty-calculator.spec.js
+++ b/tests/validate-duty-calculator.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures.js";
 import LoginPage from "../pages/loginPage.js";
 
 test.describe("Duty Calculator Integration", () => {

--- a/tests/validate-exchange-rates.spec.js
+++ b/tests/validate-exchange-rates.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures.js";
 import LoginPage from "../pages/loginPage.js";
 import DownloadHelper from "../utils/downloadHelper.js";
 import { assertExchangeRateCsv } from "../utils/exchangeRateCsv.js";
@@ -32,13 +32,14 @@ async function sampleRatesFromTable(page, codes = SAMPLE_CODES) {
   return samples;
 }
 
-async function assertCsvMatchesTable(page, breadcrumbName, sampleRates) {
-  await page
-    .getByRole("link", { name: breadcrumbName })
-    .click({ timeout: 20000 });
+async function assertCsvMatchesTable(page, sampleRates) {
   await DownloadHelper.downloadAndVerify(
     page,
-    page.getByRole("link", { name: /CSV\s+\d+\.?\d*\s*KB/ }).first(),
+    page
+      .getByRole("link", {
+        name: /CSV(?:\s+file)?\s*\(?\d+(?:\.\d+)?\s*KB\)?/,
+      })
+      .first(),
     /\.csv$/i,
     {
       assertBody: (body) => {
@@ -57,34 +58,28 @@ test.describe("Exchange Rates", () => {
     ).toBeVisible({ timeout: 20000 });
 
     const sampleRates = await sampleRatesFromTable(page);
-    await assertCsvMatchesTable(page, "Monthly exchange rates", sampleRates);
+    await assertCsvMatchesTable(page, sampleRates);
   });
 
   test("Validating average exchange rates", async ({ page }) => {
-    await new LoginPage("/exchange_rates", page).login();
-    await page
-      .getByRole("link", { name: "Currency exchange average rates" })
-      .click();
+    await new LoginPage("/exchange_rates/average", page).login();
     await page.locator('a[title^="View"]').first().click();
     await expect(
       page.getByRole("columnheader", { name: "Country/territory" }),
     ).toBeVisible({ timeout: 20000 });
 
     const sampleRates = await sampleRatesFromTable(page);
-    await assertCsvMatchesTable(page, "Average exchange rates", sampleRates);
+    await assertCsvMatchesTable(page, sampleRates);
   });
 
   test("Validating spot exchange rates", async ({ page }) => {
-    await new LoginPage("/exchange_rates", page).login();
-    await page
-      .getByRole("link", { name: "Currency exchange spot rates" })
-      .click();
+    await new LoginPage("/exchange_rates/spot", page).login();
     await page.locator('a[title^="View"]').first().click();
     await expect(
       page.getByRole("columnheader", { name: "Country/territory" }),
     ).toBeVisible({ timeout: 20000 });
 
     const sampleRates = await sampleRatesFromTable(page);
-    await assertCsvMatchesTable(page, "Spot exchange rates", sampleRates);
+    await assertCsvMatchesTable(page, sampleRates);
   });
 });

--- a/tests/validate-news-section.spec.js
+++ b/tests/validate-news-section.spec.js
@@ -1,5 +1,5 @@
 // create or open your test file tests/validate-news-section.spec.js
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures.js";
 import LoginPage from "../pages/loginPage.js";
 
 test.describe("News Section", () => {

--- a/tests/validate-simplified-procedural-measures.spec.js
+++ b/tests/validate-simplified-procedural-measures.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures.js";
 import LoginPage from "../pages/loginPage.js";
 
 test.describe("Simplified Procedural Measures", () => {

--- a/tests/validate-updates.spec.js
+++ b/tests/validate-updates.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures.js";
 import LoginPage from "../pages/loginPage.js";
 import validateTariffDate from "../utils/tariffDate.js";
 

--- a/utils/authState.js
+++ b/utils/authState.js
@@ -1,0 +1,29 @@
+export async function createAuthenticatedState(browser, options) {
+  if (!options.enabled) {
+    return { cookies: [], origins: [] };
+  }
+
+  const context = await browser.newContext({
+    baseURL: options.baseURL,
+    extraHTTPHeaders: options.extraHTTPHeaders,
+  });
+
+  try {
+    const page = await context.newPage();
+    await page.goto(options.url);
+
+    const passwordInput = page.locator("#basic-session-password-field");
+    if ((await passwordInput.count()) > 0) {
+      if (!options.password) {
+        throw new Error("BASIC_PASSWORD is required for authenticated tests");
+      }
+
+      await passwordInput.fill(options.password);
+      await page.getByRole("button", { name: "Continue" }).click();
+    }
+
+    return await context.storageState();
+  } finally {
+    await context.close();
+  }
+}

--- a/utils/authState.test.js
+++ b/utils/authState.test.js
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createAuthenticatedState } from "./authState.js";
+
+test("returns empty state without opening a browser when auth is disabled", async () => {
+  const browser = {
+    newContext() {
+      throw new Error("browser context should not be created");
+    },
+  };
+
+  const state = await createAuthenticatedState(browser, { enabled: false });
+
+  assert.deepEqual(state, { cookies: [], origins: [] });
+});
+
+test("authenticates once and returns reusable storage state", async () => {
+  const events = [];
+  const expectedState = {
+    cookies: [{ name: "session", value: "authenticated" }],
+    origins: [],
+  };
+  const page = {
+    async goto(url) {
+      events.push(["goto", url]);
+    },
+    locator(selector) {
+      assert.equal(selector, "#basic-session-password-field");
+      return {
+        async count() {
+          return 1;
+        },
+        async fill(password) {
+          events.push(["fill", password]);
+        },
+      };
+    },
+    getByRole(role, options) {
+      assert.equal(role, "button");
+      assert.deepEqual(options, { name: "Continue" });
+      return {
+        async click() {
+          events.push(["click"]);
+        },
+      };
+    },
+  };
+  const context = {
+    async newPage() {
+      return page;
+    },
+    async storageState() {
+      events.push(["storageState"]);
+      return expectedState;
+    },
+    async close() {
+      events.push(["close"]);
+    },
+  };
+  const browser = {
+    async newContext(options) {
+      events.push(["newContext", options]);
+      return context;
+    },
+  };
+
+  const state = await createAuthenticatedState(browser, {
+    enabled: true,
+    baseURL: "https://example.test",
+    url: "/find_commodity",
+    password: "secret",
+    extraHTTPHeaders: { "x-waf-bypass": "token" },
+  });
+
+  assert.deepEqual(state, expectedState);
+  assert.deepEqual(events, [
+    [
+      "newContext",
+      {
+        baseURL: "https://example.test",
+        extraHTTPHeaders: { "x-waf-bypass": "token" },
+      },
+    ],
+    ["goto", "/find_commodity"],
+    ["fill", "secret"],
+    ["click"],
+    ["storageState"],
+    ["close"],
+  ]);
+});

--- a/utils/cognitoUserCleaner.js
+++ b/utils/cognitoUserCleaner.js
@@ -4,6 +4,7 @@ import {
   ListUsersCommand,
   AdminDeleteUserCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
+import { setTimeout as sleep } from "node:timers/promises";
 
 export default class CognitoUserCleaner {
   constructor(userPoolName, region = "eu-west-2") {
@@ -37,10 +38,40 @@ export default class CognitoUserCleaner {
       });
 
       await this.client.send(deleteCommand);
+      await this.waitUntilUserDeleted(poolId, email);
       return true;
     } catch (error) {
       console.error(`Error deleting user`, error);
+      throw error;
     }
+  }
+
+  async waitUntilUserDeleted(poolId, email, options = {}) {
+    const maxWaitMs = options.maxWaitMs ?? 5_000;
+    const pollIntervalMs = options.pollIntervalMs ?? 250;
+    const wait = options.sleep ?? sleep;
+    const maxPolls = Math.ceil(maxWaitMs / pollIntervalMs);
+
+    for (let poll = 0; poll <= maxPolls; poll++) {
+      const command = new ListUsersCommand({
+        UserPoolId: poolId,
+        Filter: `email = "${email}"`,
+        Limit: 1,
+      });
+      const { Users } = await this.client.send(command);
+
+      if (!Users || Users.length === 0) {
+        return;
+      }
+
+      if (poll < maxPolls) {
+        await wait(pollIntervalMs);
+      }
+    }
+
+    throw new Error(
+      `Cognito user '${email}' still exists after ${maxWaitMs}ms`,
+    );
   }
 
   async getUserPoolIdByName(name) {

--- a/utils/cognitoUserCleaner.test.js
+++ b/utils/cognitoUserCleaner.test.js
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import CognitoUserCleaner from "./cognitoUserCleaner.js";
+
+test("waits until Cognito no longer returns the deleted user", async () => {
+  const responses = [{ Users: [{ Username: "existing-user" }] }, { Users: [] }];
+  const sleeps = [];
+  const cleaner = new CognitoUserCleaner("subscriptions");
+  cleaner.client = {
+    async send() {
+      return responses.shift();
+    },
+  };
+
+  await cleaner.waitUntilUserDeleted("pool-id", "test@example.com", {
+    maxWaitMs: 1_000,
+    pollIntervalMs: 250,
+    sleep: async (duration) => sleeps.push(duration),
+  });
+
+  assert.deepEqual(sleeps, [250]);
+  assert.equal(responses.length, 0);
+});
+
+test("confirms the user is absent after deleting it", async () => {
+  const commands = [];
+  const waits = [];
+  const cleaner = new CognitoUserCleaner("subscriptions");
+  cleaner.getUserPoolIdByName = async () => "pool-id";
+  cleaner.client = {
+    async send(command) {
+      commands.push(command.constructor.name);
+      if (command.constructor.name === "ListUsersCommand") {
+        return { Users: [{ Username: "existing-user" }] };
+      }
+      return {};
+    },
+  };
+  cleaner.waitUntilUserDeleted = async (poolId, email) => {
+    waits.push([poolId, email]);
+  };
+
+  const deleted = await cleaner.deleteUserByEmail("test@example.com");
+
+  assert.equal(deleted, true);
+  assert.deepEqual(commands, ["ListUsersCommand", "AdminDeleteUserCommand"]);
+  assert.deepEqual(waits, [["pool-id", "test@example.com"]]);
+});
+
+test("fails when deletion cannot be confirmed", async (context) => {
+  context.mock.method(console, "error", () => {});
+  const cleaner = new CognitoUserCleaner("subscriptions");
+  cleaner.getUserPoolIdByName = async () => "pool-id";
+  cleaner.client = {
+    async send(command) {
+      if (command.constructor.name === "ListUsersCommand") {
+        return { Users: [{ Username: "existing-user" }] };
+      }
+      return {};
+    },
+  };
+  cleaner.waitUntilUserDeleted = async () => {
+    throw new Error("user still exists");
+  };
+
+  await assert.rejects(
+    cleaner.deleteUserByEmail("test@example.com"),
+    /user still exists/,
+  );
+});


### PR DESCRIPTION
# Jira link

No ticket/issue

## What?

I have:

- [x] Added worker-scoped reusable authentication state and focused unit coverage
- [x] Removed network-idle waits and fixed subscription sleeps
- [x] Altered exchange-rate journeys to navigate directly while preserving content and CSV assertions
- [x] Kept CI browser execution at two workers

## Why?

I am doing this because:

- Repeating basic authentication for every test adds avoidable browser work
- Direct navigation and condition-based polling reduce elapsed time without weakening assertions
- The production suite remains robust while avoiding additional client runner cost
