### PR TITLE
Potential fix for code scanning alert no. 24: Clear-text logging of sensitive information

### DIFF
--- a/utils/cognitoUserCleaner.js
+++ b/utils/cognitoUserCleaner.js
@@ -41,7 +41,9 @@ export default class CognitoUserCleaner {
       await this.waitUntilUserDeleted(poolId, email);
       return true;
     } catch (error) {
-      console.error(`Error deleting user`, error);
+      console.error("Error deleting user from Cognito", {
+        name: error?.name,
+      });
       throw error;
     }
   }
@@ -70,7 +72,7 @@ export default class CognitoUserCleaner {
     }
 
     throw new Error(
-      `Cognito user '${email}' still exists after ${maxWaitMs}ms`,
+      `Cognito user still exists after ${maxWaitMs}ms`,
     );
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/trade-tariff/trade-tariff-e2e-tests/security/code-scanning/24](https://github.com/trade-tariff/trade-tariff-e2e-tests/security/code-scanning/24)

General fix approach: never log raw exception objects when they may contain sensitive payloads; log a sanitized/static message (optionally with non-sensitive metadata like error name/code), and keep throwing the original error so behavior is unchanged for callers.

Best fix in this code:
1. In `utils/cognitoUserCleaner.js` at the `catch` block in `deleteUserByEmail`, replace `console.error("Error deleting user", error)` with a sanitized log that does not print the full error object or message content.
2. In `waitUntilUserDeleted`, remove the email value from the thrown timeout error text so sensitive data is not propagated into downstream logs.

This preserves functionality (same control flow, same exceptions thrown), while preventing clear-text sensitive data from entering logs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
